### PR TITLE
Port endpoint_manager to latest node_id API

### DIFF
--- a/libcaf_net/test/endpoint_manager.cpp
+++ b/libcaf_net/test/endpoint_manager.cpp
@@ -119,7 +119,8 @@ public:
   template <class Manager>
   void resolve(Manager& mgr, std::string path, actor listener) {
     actor_id aid = 42;
-    node_id nid{42, "00112233445566778899aa00112233445566778899aa"};
+    auto hid = "0011223344556677889900112233445566778899";
+    auto nid = unbox(make_node_id(42, hid));
     actor_config cfg;
     auto p = make_actor<actor_proxy_impl, strong_actor_ptr>(aid, nid,
                                                             &mgr.system(), cfg,


### PR DESCRIPTION
This PR ports the `endpoint_manager` to the new `node_id` API after merging https://github.com/actor-framework/actor-framework/pull/863.