### PR TITLE
Add function to resolve local addresses and interface names

### DIFF
--- a/libcaf_net/caf/net/ip.hpp
+++ b/libcaf_net/caf/net/ip.hpp
@@ -30,6 +30,10 @@ namespace ip {
 /// Returns all IP addresses of to `host` (if any).
 std::vector<ip_address> resolve(string_view host);
 
+/// Returns the IP addresses for a local endpoint, which is either an address,
+/// an interface, or localhost.
+std::vector<ip_address> local_addresses(string_view host);
+
 /// Returns the hostname of this device.
 std::string hostname();
 

--- a/libcaf_net/caf/net/ip.hpp
+++ b/libcaf_net/caf/net/ip.hpp
@@ -30,9 +30,15 @@ namespace ip {
 /// Returns all IP addresses of to `host` (if any).
 std::vector<ip_address> resolve(string_view host);
 
+/// Returns all IP addresses of to `host` (if any).
+std::vector<ip_address> resolve(ip_address host);
+
 /// Returns the IP addresses for a local endpoint, which is either an address,
-/// an interface, or localhost.
+/// an interface name, or the string "localhost".
 std::vector<ip_address> local_addresses(string_view host);
+
+/// Returns the IP addresses for a local endpoint address.
+std::vector<ip_address> local_addresses(ip_address host);
 
 /// Returns the hostname of this device.
 std::string hostname();

--- a/libcaf_net/caf/net/ip.hpp
+++ b/libcaf_net/caf/net/ip.hpp
@@ -27,10 +27,10 @@ namespace caf {
 namespace net {
 namespace ip {
 
-/// Returns all IP addresses of to `host` (if any).
+/// Returns all IP addresses of `host` (if any).
 std::vector<ip_address> resolve(string_view host);
 
-/// Returns all IP addresses of to `host` (if any).
+/// Returns all IP addresses of `host` (if any).
 std::vector<ip_address> resolve(ip_address host);
 
 /// Returns the IP addresses for a local endpoint, which is either an address,

--- a/libcaf_net/src/ip.cpp
+++ b/libcaf_net/src/ip.cpp
@@ -58,10 +58,10 @@ namespace ip {
 namespace {
 
 // Dummy port to resolve empty string with getaddrinfo.
-constexpr auto dummy_port = "42";
-constexpr auto v4_any_addr = "0.0.0.0";
-constexpr auto v6_any_addr = "::";
-constexpr auto localhost = "localhost";
+constexpr string_view dummy_port = "42";
+constexpr string_view v4_any_addr = "0.0.0.0";
+constexpr string_view v6_any_addr = "::";
+constexpr string_view localhost = "localhost";
 
 void* fetch_in_addr(int family, sockaddr* addr) {
   if (family == AF_INET)
@@ -115,7 +115,7 @@ std::vector<ip_address> resolve(string_view host) {
   addrinfo* tmp = nullptr;
   std::string host_str{host.begin(), host.end()};
   if (getaddrinfo(host.empty() ? nullptr : host_str.c_str(),
-                  host.empty() ? dummy_port : nullptr, &hint, &tmp)
+                  host.empty() ? dummy_port.data() : nullptr, &hint, &tmp)
       != 0)
     return {};
   std::unique_ptr<addrinfo, decltype(freeaddrinfo)*> addrs{tmp, freeaddrinfo};
@@ -151,9 +151,9 @@ std::string hostname() {
 std::vector<ip_address> local_addresses(string_view host) {
   using adapters_ptr = std::unique_ptr<IP_ADAPTER_ADDRESSES, void (*)(void*)>;
   using wbuf_ptr = std::unique_ptr<IP_ADAPTER_ADDRESSES, void (*)(void*)>;
-  if (!host.empty() && host.compare(v4_any_addr) == 0)
+  if (host == v4_any_addr)
     return {ip_address{make_ipv4_address(0, 0, 0, 0)}};
-  if (!host.empty() && host.compare(v6_any_addr) == 0)
+  if (host == v6_any_addr)
     return {ip_address{}};
   ULONG len = 0;
   auto err = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr,
@@ -214,9 +214,9 @@ std::vector<ip_address> local_addresses(string_view host) {
 #else // CAF_WINDOWS
 
 std::vector<ip_address> local_addresses(string_view host) {
-  if (!host.empty() && host.compare(v4_any_addr) == 0)
+  if (host == v4_any_addr)
     return {ip_address{make_ipv4_address(0, 0, 0, 0)}};
-  if (!host.empty() && host.compare(v6_any_addr) == 0)
+  if (host == v6_any_addr)
     return {ip_address{}};
   ifaddrs* tmp = nullptr;
   if (getifaddrs(&tmp) != 0)

--- a/libcaf_net/src/ip.cpp
+++ b/libcaf_net/src/ip.cpp
@@ -94,7 +94,7 @@ void for_each_adapter(F f, bool is_link_local = false) {
     return;
   }
   auto adapters = adapters_ptr{reinterpret_cast<IP_ADAPTER_ADDRESSES*>(
-                                 ::malloc(len),
+                                 ::malloc(len)),
                                free};
   if (!adapters) {
     CAF_LOG_ERROR("malloc failed");
@@ -123,7 +123,7 @@ void for_each_adapter(F f, bool is_link_local = false) {
       getnameinfo(addr->Address.lpSockaddr, addr->Address.iSockaddrLength,
                   ip_buf, sizeof(ip_buf), nullptr, 0, NI_NUMERICHOST);
       ip_address ip;
-      if (!is_link_local && starts_with(if_buf, "fe80:")) {
+      if (!is_link_local && starts_with(ip_buf, "fe80:")) {
         CAF_LOG_DEBUG("skipping link-local address: " << ip_buf);
         continue;
       } else if (auto err = parse(ip_buf, ip))

--- a/libcaf_net/src/ip.cpp
+++ b/libcaf_net/src/ip.cpp
@@ -217,9 +217,9 @@ std::vector<ip_address> local_addresses(string_view host) {
 
 std::vector<ip_address> local_addresses(string_view host) {
   if (!host.empty() && host.compare(v4_any_addr) == 0)
-    return { ip_address{ make_ipv4_address(0, 0, 0, 0) } };
+    return {ip_address{make_ipv4_address(0, 0, 0, 0)}};
   if (!host.empty() && host.compare(v6_any_addr) == 0)
-    return { ip_address{} };
+    return {ip_address{}};
   ifaddrs* tmp = nullptr;
   if (getifaddrs(&tmp) != 0)
     return {};

--- a/libcaf_net/src/ip.cpp
+++ b/libcaf_net/src/ip.cpp
@@ -226,13 +226,10 @@ std::vector<ip_address> local_addresses(string_view host) {
 }
 
 std::vector<ip_address> local_addresses(ip_address host) {
-  auto v6_any = ip_address{{0}, {0}};
-  auto v4_any = ip_address{make_ipv4_address(0, 0, 0, 0)};
-  // TODO: If is any addr, call resolve with PR #23.
-  if (host == v4_any)
-    return {ip_address{make_ipv4_address(0, 0, 0, 0)}};
-  if (host == v6_any)
-    return {ip_address{}};
+  static auto v6_any = ip_address{{0}, {0}};
+  static auto v4_any = ip_address{make_ipv4_address(0, 0, 0, 0)};
+  if (host == v4_any || host == v6_any)
+    return resolve("");
   auto link_local = ip_address({0xfe, 0x8, 0x0, 0x0}, {0x0, 0x0, 0x0, 0x0});
   auto ll_prefix = ip_subnet(link_local, 10);
   // Unless explicitly specified we are going to skip link-local addresses.

--- a/libcaf_net/src/ip.cpp
+++ b/libcaf_net/src/ip.cpp
@@ -43,10 +43,6 @@
 #  include <sys/ioctl.h>
 #endif
 
-#ifdef CAF_WINDOWS
-#  pragma comment(lib, "IPHLPAPI.lib")
-#endif
-
 #ifndef HOST_NAME_MAX
 #  define HOST_NAME_MAX 255
 #endif
@@ -173,7 +169,9 @@ std::vector<ip_address> local_addresses(string_view host) {
     CAF_LOG_ERROR("malloc failed");
     return {};
   }
-  // TODO: The API example propopses to try three times.
+  // TODO: The Microsoft WIN32 API example propopses to try three times, other
+  // examples online just perform the call once. If we notice the call to be
+  // unreliable, we might adapt that behavior.
   err = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr,
                              adapters.get(), &len);
   if (err != ERROR_SUCCESS) {

--- a/libcaf_net/src/ip.cpp
+++ b/libcaf_net/src/ip.cpp
@@ -96,8 +96,8 @@ void find_by_addr(const vector<pair<string, ip_address>>& interfaces,
 
 void find_localhost(const vector<pair<string, ip_address>>& interfaces,
                     vector<ip_address>& results) {
-  auto v4_local = ip_address{{0}, {0x1}};
-  auto v6_local = ip_address{make_ipv4_address(127, 0, 0, 1)};
+  auto v6_local = ip_address{{0}, {0x1}};
+  auto v4_local = ip_address{make_ipv4_address(127, 0, 0, 1)};
   for (auto& p : interfaces)
     if (p.second == v4_local || p.second == v6_local)
       results.push_back(p.second);

--- a/libcaf_net/test/ip.cpp
+++ b/libcaf_net/test/ip.cpp
@@ -35,13 +35,15 @@ namespace {
 struct fixture : host_fixture {
   fixture() : v6_local{{0}, {0x1}} {
     v4_local = ip_address{make_ipv4_address(127, 0, 0, 1)};
+    v4_any_addr = ip_address{ make_ipv4_address(0, 0, 0, 0) };
   }
 
   bool contains(ip_address x) {
     return std::count(addrs.begin(), addrs.end(), x) > 0;
   }
 
-  ip_address any_addr;
+  ip_address v4_any_addr;
+  ip_address v6_any_addr;
   ip_address v4_local;
   ip_address v6_local;
 
@@ -70,16 +72,14 @@ CAF_TEST(resolve any) {
 }
 
 CAF_TEST(local addresses) {
-  // This is not that easy to test. There are few hard-coded addresses we can
-  // check.
-  CAF_MESSAGE("check: v6");
-  addrs = ip::local_addresses("::");
-  CAF_CHECK(!addrs.empty());
-  CAF_CHECK(contains(any_addr));
   CAF_MESSAGE("check: v4");
   addrs = ip::local_addresses("0.0.0.0");
   CAF_CHECK(!addrs.empty());
-  CAF_CHECK(contains(any_addr));
+  CAF_CHECK(contains(v4_any_addr));
+  CAF_MESSAGE("check: v6");
+  addrs = ip::local_addresses("::");
+  CAF_CHECK(!addrs.empty());
+  CAF_CHECK(contains(v6_any_addr));
   CAF_MESSAGE("check: localhost");
   addrs = ip::local_addresses("localhost");
   CAF_CHECK(!addrs.empty());

--- a/libcaf_net/test/ip.cpp
+++ b/libcaf_net/test/ip.cpp
@@ -61,29 +61,23 @@ CAF_TEST(resolve localhost) {
 }
 
 CAF_TEST(resolve any) {
-  ip_address v4_any{make_ipv4_address(0, 0, 0, 0)};
-  ip_address v6_any{{0}, {0}};
-  auto addrs = ip::resolve("");
+  addrs = ip::resolve("");
   CAF_CHECK(!addrs.empty());
-  auto contains = [&](ip_address x) {
-    return std::count(addrs.begin(), addrs.end(), x) > 0;
-  };
-  CAF_CHECK(contains(v4_any) || contains(v6_any));
+  CAF_CHECK(contains(v4_any_addr) || contains(v6_any_addr));
 }
 
-CAF_TEST(local addresses) {
-  CAF_MESSAGE("check: v4");
-  addrs = ip::local_addresses("0.0.0.0");
-  CAF_CHECK(!addrs.empty());
-  CAF_CHECK(contains(v4_any_addr));
-  CAF_MESSAGE("check: v6");
-  addrs = ip::local_addresses("::");
-  CAF_CHECK(!addrs.empty());
-  CAF_CHECK(contains(v6_any_addr));
-  CAF_MESSAGE("check: localhost");
+CAF_TEST(local addresses localhost) {
   addrs = ip::local_addresses("localhost");
   CAF_CHECK(!addrs.empty());
   CAF_CHECK(contains(v4_local) || contains(v6_local));
+}
+
+CAF_TEST(local addresses any) {
+  addrs = ip::local_addresses("0.0.0.0");
+  auto tmp = ip::local_addresses("::");
+  addrs.insert(addrs.end(), tmp.begin(), tmp.end());
+  CAF_CHECK(!addrs.empty());
+  CAF_CHECK(contains(v4_any_addr) || contains(v6_any_addr));
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_net/test/ip.cpp
+++ b/libcaf_net/test/ip.cpp
@@ -35,7 +35,7 @@ namespace {
 struct fixture : host_fixture {
   fixture() : v6_local{{0}, {0x1}} {
     v4_local = ip_address{make_ipv4_address(127, 0, 0, 1)};
-    v4_any_addr = ip_address{ make_ipv4_address(0, 0, 0, 0) };
+    v4_any_addr = ip_address{make_ipv4_address(0, 0, 0, 0)};
   }
 
   bool contains(ip_address x) {
@@ -83,7 +83,7 @@ CAF_TEST(local addresses) {
   CAF_MESSAGE("check: localhost");
   addrs = ip::local_addresses("localhost");
   CAF_CHECK(!addrs.empty());
-  CAF_CHECK(contains(v4_local) && contains(v6_local));
+  CAF_CHECK(contains(v4_local) || contains(v6_local));
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
The lookup of the any addresses is currently hard coded. We could redirect to resolve for these provided something [like this](https://github.com/actor-framework/incubator/commit/aa2bd7b9efcde2e143f2f8a5ef8ed3cc85212bd3) is acceptable. 