### PR TITLE
Fix basp::application test

### DIFF
--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -191,7 +191,7 @@ private:
   std::unordered_set<actor_addr> monitored_actors_; // TODO: this is unused
 
   /// Caches actor handles obtained via `resolve`.
-  std::unordered_map<uint64_t, response_promise> pending_resolves_;
+  std::unordered_map<uint64_t, actor> pending_resolves_;
 
   /// Ascending ID generator for requests to our peer.
   uint64_t next_request_id_ = 1;


### PR DESCRIPTION
This PR fixes the `basp::application` test which was broken by a recent change in `response_promise`.