### PR TITLE
Add all.hpp header

### DIFF
--- a/libcaf_net/caf/net/all.hpp
+++ b/libcaf_net/caf/net/all.hpp
@@ -51,17 +51,3 @@
 #include "caf/net/transport_worker.hpp"
 #include "caf/net/transport_worker_dispatcher.hpp"
 #include "caf/net/udp_datagram_socket.hpp"
-
-#include "caf/net/backend/test.hpp"
-
-#include "caf/net/basp/application.hpp"
-#include "caf/net/basp/connection_state.hpp"
-#include "caf/net/basp/constants.hpp"
-#include "caf/net/basp/ec.hpp"
-#include "caf/net/basp/header.hpp"
-#include "caf/net/basp/message_queue.hpp"
-#include "caf/net/basp/message_type.hpp"
-#include "caf/net/basp/remote_message_handler.hpp"
-#include "caf/net/basp/worker.hpp"
-
-#include "caf/net/test/host_fixture.hpp"

--- a/libcaf_net/caf/net/all.hpp
+++ b/libcaf_net/caf/net/all.hpp
@@ -1,0 +1,67 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "caf/net/actor_proxy_impl.hpp"
+#include "caf/net/datagram_socket.hpp"
+#include "caf/net/datagram_transport.hpp"
+#include "caf/net/defaults.hpp"
+#include "caf/net/endpoint_manager.hpp"
+#include "caf/net/endpoint_manager_impl.hpp"
+#include "caf/net/endpoint_manager_queue.hpp"
+#include "caf/net/fwd.hpp"
+#include "caf/net/host.hpp"
+#include "caf/net/ip.hpp"
+#include "caf/net/make_endpoint_manager.hpp"
+#include "caf/net/middleman.hpp"
+#include "caf/net/middleman_backend.hpp"
+#include "caf/net/multiplexer.hpp"
+#include "caf/net/network_socket.hpp"
+#include "caf/net/operation.hpp"
+#include "caf/net/packet_writer.hpp"
+#include "caf/net/packet_writer_decorator.hpp"
+#include "caf/net/pipe_socket.hpp"
+#include "caf/net/pollset_updater.hpp"
+#include "caf/net/receive_policy.hpp"
+#include "caf/net/socket.hpp"
+#include "caf/net/socket_guard.hpp"
+#include "caf/net/socket_id.hpp"
+#include "caf/net/socket_manager.hpp"
+#include "caf/net/stream_socket.hpp"
+#include "caf/net/stream_transport.hpp"
+#include "caf/net/tcp_accept_socket.hpp"
+#include "caf/net/tcp_stream_socket.hpp"
+#include "caf/net/transport_base.hpp"
+#include "caf/net/transport_worker.hpp"
+#include "caf/net/transport_worker_dispatcher.hpp"
+#include "caf/net/udp_datagram_socket.hpp"
+
+#include "caf/net/backend/test.hpp"
+
+#include "caf/net/basp/application.hpp"
+#include "caf/net/basp/connection_state.hpp"
+#include "caf/net/basp/constants.hpp"
+#include "caf/net/basp/ec.hpp"
+#include "caf/net/basp/header.hpp"
+#include "caf/net/basp/message_queue.hpp"
+#include "caf/net/basp/message_type.hpp"
+#include "caf/net/basp/remote_message_handler.hpp"
+#include "caf/net/basp/worker.hpp"
+
+#include "caf/net/test/host_fixture.hpp"


### PR DESCRIPTION
This PR adds the `all.hpp` header so a `FindCAF_NET.cmake` script can find the built library.