### PR TITLE
Refactor code to use new binary_serializer

### DIFF
--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -46,7 +46,6 @@
 #include "caf/proxy_registry.hpp"
 #include "caf/response_promise.hpp"
 #include "caf/scoped_execution_unit.hpp"
-#include "caf/span.hpp"
 #include "caf/unit.hpp"
 
 namespace caf::net::basp {

--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -46,7 +46,6 @@
 #include "caf/proxy_registry.hpp"
 #include "caf/response_promise.hpp"
 #include "caf/scoped_execution_unit.hpp"
-#include "caf/serializer_impl.hpp"
 #include "caf/span.hpp"
 #include "caf/unit.hpp"
 

--- a/libcaf_net/caf/net/datagram_transport.hpp
+++ b/libcaf_net/caf/net/datagram_transport.hpp
@@ -87,7 +87,7 @@ public:
       CAF_LOG_DEBUG("received " << num_bytes << " bytes");
       auto ep = res->second;
       this->read_buf_.resize(num_bytes);
-      this->next_layer_.handle_data(*this, make_span(this->read_buf_),
+      this->next_layer_.handle_data(*this, as_bytes(make_span(this->read_buf_)),
                                     std::move(ep));
       prepare_next_read();
     } else {

--- a/libcaf_net/caf/net/datagram_transport.hpp
+++ b/libcaf_net/caf/net/datagram_transport.hpp
@@ -87,7 +87,7 @@ public:
       CAF_LOG_DEBUG("received " << num_bytes << " bytes");
       auto ep = res->second;
       this->read_buf_.resize(num_bytes);
-      this->next_layer_.handle_data(*this, as_bytes(make_span(this->read_buf_)),
+      this->next_layer_.handle_data(*this, make_span(this->read_buf_),
                                     std::move(ep));
       prepare_next_read();
     } else {

--- a/libcaf_net/caf/net/packet_writer_decorator.hpp
+++ b/libcaf_net/caf/net/packet_writer_decorator.hpp
@@ -21,7 +21,6 @@
 #include "caf/net/packet_writer.hpp"
 
 #include "caf/byte.hpp"
-#include "caf/span.hpp"
 
 namespace caf::net {
 

--- a/libcaf_net/caf/net/stream_transport.hpp
+++ b/libcaf_net/caf/net/stream_transport.hpp
@@ -85,8 +85,8 @@ public:
       this->collected_ += *num_bytes;
       if (this->collected_ >= this->read_threshold_) {
         if (auto err = this->next_layer_.handle_data(*this,
-                                                     as_bytes(make_span(
-                                                       this->read_buf_)))) {
+                                                     make_span(
+                                                       this->read_buf_))) {
           CAF_LOG_ERROR("handle_data failed: " << CAF_ARG(err));
           return false;
         }
@@ -186,7 +186,7 @@ private:
       CAF_ASSERT(!buf.empty());
       auto data = buf.data() + written_;
       auto len = buf.size() - written_;
-      auto write_ret = write(this->handle(), as_bytes(make_span(data, len)));
+      auto write_ret = write(this->handle(), make_span(data, len));
       if (auto num_bytes = get_if<size_t>(&write_ret)) {
         CAF_LOG_DEBUG(CAF_ARG(this->handle_.id) << CAF_ARG(*num_bytes));
         written_ += *num_bytes;

--- a/libcaf_net/caf/net/stream_transport.hpp
+++ b/libcaf_net/caf/net/stream_transport.hpp
@@ -84,7 +84,9 @@ public:
                     << CAF_ARG(this->handle_.id) << CAF_ARG(*num_bytes));
       this->collected_ += *num_bytes;
       if (this->collected_ >= this->read_threshold_) {
-        if (auto err = this->next_layer_.handle_data(*this, this->read_buf_)) {
+        if (auto err = this->next_layer_.handle_data(*this,
+                                                     as_bytes(make_span(
+                                                       this->read_buf_)))) {
           CAF_LOG_ERROR("handle_data failed: " << CAF_ARG(err));
           return false;
         }
@@ -184,7 +186,7 @@ private:
       CAF_ASSERT(!buf.empty());
       auto data = buf.data() + written_;
       auto len = buf.size() - written_;
-      auto write_ret = write(this->handle(), make_span(data, len));
+      auto write_ret = write(this->handle(), as_bytes(make_span(data, len)));
       if (auto num_bytes = get_if<size_t>(&write_ret)) {
         CAF_LOG_DEBUG(CAF_ARG(this->handle_.id) << CAF_ARG(*num_bytes));
         written_ += *num_bytes;

--- a/libcaf_net/caf/net/transport_worker_dispatcher.hpp
+++ b/libcaf_net/caf/net/transport_worker_dispatcher.hpp
@@ -62,7 +62,7 @@ public:
   }
 
   template <class Parent>
-  error handle_data(Parent& parent, span<byte> data, id_type id) {
+  error handle_data(Parent& parent, span<const byte> data, id_type id) {
     if (auto worker = find_worker(id))
       return worker->handle_data(parent, data);
     // TODO: Where to get node_id from here?

--- a/libcaf_net/src/host.cpp
+++ b/libcaf_net/src/host.cpp
@@ -22,6 +22,8 @@
 #include "caf/detail/net_syscall.hpp"
 #include "caf/detail/socket_sys_includes.hpp"
 #include "caf/error.hpp"
+#include "caf/make_message.hpp"
+#include "caf/message.hpp"
 #include "caf/net/socket.hpp"
 #include "caf/none.hpp"
 

--- a/libcaf_net/src/multiplexer.cpp
+++ b/libcaf_net/src/multiplexer.cpp
@@ -274,7 +274,7 @@ void multiplexer::write_to_pipe(uint8_t opcode, const socket_manager_ptr& mgr) {
   { // Lifetime scope of guard.
     std::lock_guard<std::mutex> guard{write_lock_};
     if (write_handle_ != invalid_socket)
-      res = write(write_handle_, as_bytes(make_span(buf)));
+      res = write(write_handle_, make_span(buf));
     else
       res = sec::socket_invalid;
   }

--- a/libcaf_net/src/multiplexer.cpp
+++ b/libcaf_net/src/multiplexer.cpp
@@ -274,7 +274,7 @@ void multiplexer::write_to_pipe(uint8_t opcode, const socket_manager_ptr& mgr) {
   { // Lifetime scope of guard.
     std::lock_guard<std::mutex> guard{write_lock_};
     if (write_handle_ != invalid_socket)
-      res = write(write_handle_, make_span(buf));
+      res = write(write_handle_, as_bytes(make_span(buf)));
     else
       res = sec::socket_invalid;
   }

--- a/libcaf_net/src/multiplexer.cpp
+++ b/libcaf_net/src/multiplexer.cpp
@@ -274,7 +274,7 @@ void multiplexer::write_to_pipe(uint8_t opcode, const socket_manager_ptr& mgr) {
   { // Lifetime scope of guard.
     std::lock_guard<std::mutex> guard{write_lock_};
     if (write_handle_ != invalid_socket)
-      res = write(write_handle_, make_span(buf));
+      res = write(write_handle_, buf);
     else
       res = sec::socket_invalid;
   }

--- a/libcaf_net/src/pipe_socket.cpp
+++ b/libcaf_net/src/pipe_socket.cpp
@@ -30,7 +30,6 @@
 #include "caf/message.hpp"
 #include "caf/net/stream_socket.hpp"
 #include "caf/sec.hpp"
-#include "caf/span.hpp"
 #include "caf/variant.hpp"
 
 namespace caf::net {

--- a/libcaf_net/src/pipe_socket.cpp
+++ b/libcaf_net/src/pipe_socket.cpp
@@ -19,16 +19,15 @@
 #include "caf/net/pipe_socket.hpp"
 
 #include <cstdio>
-#include <cstdlib>
 #include <utility>
 
 #include "caf/byte.hpp"
-#include "caf/config.hpp"
-#include "caf/detail/net_syscall.hpp"
+#include "caf/detail/scope_guard.hpp"
 #include "caf/detail/socket_sys_aliases.hpp"
 #include "caf/detail/socket_sys_includes.hpp"
-#include "caf/error.hpp"
 #include "caf/expected.hpp"
+#include "caf/make_message.hpp"
+#include "caf/message.hpp"
 #include "caf/net/stream_socket.hpp"
 #include "caf/sec.hpp"
 #include "caf/span.hpp"

--- a/libcaf_net/src/pollset_updater.cpp
+++ b/libcaf_net/src/pollset_updater.cpp
@@ -18,6 +18,8 @@
 
 #include "caf/net/pollset_updater.hpp"
 
+#include <cstring>
+
 #include "caf/net/multiplexer.hpp"
 #include "caf/sec.hpp"
 #include "caf/span.hpp"

--- a/libcaf_net/src/stream_socket.cpp
+++ b/libcaf_net/src/stream_socket.cpp
@@ -24,7 +24,6 @@
 #include "caf/detail/socket_sys_includes.hpp"
 #include "caf/expected.hpp"
 #include "caf/logger.hpp"
-#include "caf/span.hpp"
 #include "caf/variant.hpp"
 
 #ifdef CAF_POSIX

--- a/libcaf_net/src/udp_datagram_socket.cpp
+++ b/libcaf_net/src/udp_datagram_socket.cpp
@@ -27,7 +27,6 @@
 #include "caf/ip_endpoint.hpp"
 #include "caf/logger.hpp"
 #include "caf/net/socket_guard.hpp"
-#include "caf/span.hpp"
 
 namespace caf::net {
 

--- a/libcaf_net/test/application.cpp
+++ b/libcaf_net/test/application.cpp
@@ -58,7 +58,7 @@ struct fixture : test_coordinator_fixture<>,
   template <class... Ts>
   buffer_type to_buf(const Ts&... xs) {
     buffer_type buf;
-    serializer_impl<buffer_type> sink{system(), buf};
+    binary_serializer sink{system(), buf};
     REQUIRE_OK(sink(xs...));
     return buf;
   }
@@ -75,16 +75,16 @@ struct fixture : test_coordinator_fixture<>,
     set_input(basp::header{basp::message_type::handshake,
                            static_cast<uint32_t>(payload.size()),
                            basp::version});
-    REQUIRE_OK(app.handle_data(*this, input));
+    REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(input))));
     CAF_CHECK_EQUAL(app.state(),
                     basp::connection_state::await_handshake_payload);
-    REQUIRE_OK(app.handle_data(*this, payload));
+    REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(payload))));
   }
 
   void consume_handshake() {
     if (output.size() < basp::header_size)
       CAF_FAIL("BASP application did not write a handshake header");
-    auto hdr = basp::header::from_bytes(output);
+    auto hdr = basp::header::from_bytes(as_bytes(make_span(output)));
     if (hdr.type != basp::message_type::handshake || hdr.payload_len == 0
         || hdr.operation_data != basp::version)
       CAF_FAIL("invalid handshake header");
@@ -158,10 +158,10 @@ protected:
   do {                                                                         \
     auto payload = to_buf(__VA_ARGS__);                                        \
     set_input(basp::header{kind, static_cast<uint32_t>(payload.size()), op});  \
-    if (auto err = app.handle_data(*this, input))                              \
+    if (auto err = app.handle_data(*this, as_bytes(make_span(input))))         \
       CAF_FAIL("application-under-test failed to process header: "             \
                << sys.render(err));                                            \
-    if (auto err = app.handle_data(*this, payload))                            \
+    if (auto err = app.handle_data(*this, as_bytes(make_span(payload))))       \
       CAF_FAIL("application-under-test failed to process payload: "            \
                << sys.render(err));                                            \
   } while (false)
@@ -185,19 +185,22 @@ CAF_TEST_FIXTURE_SCOPE(application_tests, fixture)
 CAF_TEST(missing handshake) {
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_header);
   set_input(basp::header{basp::message_type::heartbeat, 0, 0});
-  CAF_CHECK_EQUAL(app.handle_data(*this, input), basp::ec::missing_handshake);
+  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(input))),
+                  basp::ec::missing_handshake);
 }
 
 CAF_TEST(version mismatch) {
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_header);
   set_input(basp::header{basp::message_type::handshake, 0, 0});
-  CAF_CHECK_EQUAL(app.handle_data(*this, input), basp::ec::version_mismatch);
+  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(input))),
+                  basp::ec::version_mismatch);
 }
 
 CAF_TEST(missing payload in handshake) {
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_header);
   set_input(basp::header{basp::message_type::handshake, 0, basp::version});
-  CAF_CHECK_EQUAL(app.handle_data(*this, input), basp::ec::missing_payload);
+  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(input))),
+                  basp::ec::missing_payload);
 }
 
 CAF_TEST(invalid handshake) {
@@ -207,9 +210,10 @@ CAF_TEST(invalid handshake) {
   auto payload = to_buf(no_nid, no_ids);
   set_input(basp::header{basp::message_type::handshake,
                          static_cast<uint32_t>(payload.size()), basp::version});
-  REQUIRE_OK(app.handle_data(*this, input));
+  REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(input))));
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_payload);
-  CAF_CHECK_EQUAL(app.handle_data(*this, payload), basp::ec::invalid_handshake);
+  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(payload))),
+                  basp::ec::invalid_handshake);
 }
 
 CAF_TEST(app identifier mismatch) {
@@ -218,9 +222,9 @@ CAF_TEST(app identifier mismatch) {
   auto payload = to_buf(mars, wrong_ids);
   set_input(basp::header{basp::message_type::handshake,
                          static_cast<uint32_t>(payload.size()), basp::version});
-  REQUIRE_OK(app.handle_data(*this, input));
+  REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(input))));
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_payload);
-  CAF_CHECK_EQUAL(app.handle_data(*this, payload),
+  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(payload))),
                   basp::ec::app_identifiers_mismatch);
 }
 
@@ -233,8 +237,8 @@ CAF_TEST(repeated handshake) {
   auto payload = to_buf(no_nid, no_ids);
   set_input(basp::header{basp::message_type::handshake,
                          static_cast<uint32_t>(payload.size()), basp::version});
-  CAF_CHECK_EQUAL(app.handle_data(*this, input), none);
-  CAF_CHECK_EQUAL(app.handle_data(*this, payload),
+  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(input))), none);
+  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(payload))),
                   basp::ec::unexpected_handshake);
 }
 
@@ -333,7 +337,7 @@ CAF_TEST(heartbeat message) {
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_header);
   auto bytes = to_bytes(basp::header{basp::message_type::heartbeat, 0, 0});
   set_input(bytes);
-  REQUIRE_OK(app.handle_data(*this, input));
+  REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(input))));
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_header);
 }
 

--- a/libcaf_net/test/application.cpp
+++ b/libcaf_net/test/application.cpp
@@ -75,16 +75,16 @@ struct fixture : test_coordinator_fixture<>,
     set_input(basp::header{basp::message_type::handshake,
                            static_cast<uint32_t>(payload.size()),
                            basp::version});
-    REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(input))));
+    REQUIRE_OK(app.handle_data(*this, make_span(input)));
     CAF_CHECK_EQUAL(app.state(),
                     basp::connection_state::await_handshake_payload);
-    REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(payload))));
+    REQUIRE_OK(app.handle_data(*this, make_span(payload)));
   }
 
   void consume_handshake() {
     if (output.size() < basp::header_size)
       CAF_FAIL("BASP application did not write a handshake header");
-    auto hdr = basp::header::from_bytes(as_bytes(make_span(output)));
+    auto hdr = basp::header::from_bytes(make_span(output));
     if (hdr.type != basp::message_type::handshake || hdr.payload_len == 0
         || hdr.operation_data != basp::version)
       CAF_FAIL("invalid handshake header");
@@ -158,10 +158,10 @@ protected:
   do {                                                                         \
     auto payload = to_buf(__VA_ARGS__);                                        \
     set_input(basp::header{kind, static_cast<uint32_t>(payload.size()), op});  \
-    if (auto err = app.handle_data(*this, as_bytes(make_span(input))))         \
+    if (auto err = app.handle_data(*this, make_span(input)))                   \
       CAF_FAIL("application-under-test failed to process header: "             \
                << sys.render(err));                                            \
-    if (auto err = app.handle_data(*this, as_bytes(make_span(payload))))       \
+    if (auto err = app.handle_data(*this, make_span(payload)))                 \
       CAF_FAIL("application-under-test failed to process payload: "            \
                << sys.render(err));                                            \
   } while (false)
@@ -185,21 +185,21 @@ CAF_TEST_FIXTURE_SCOPE(application_tests, fixture)
 CAF_TEST(missing handshake) {
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_header);
   set_input(basp::header{basp::message_type::heartbeat, 0, 0});
-  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(input))),
+  CAF_CHECK_EQUAL(app.handle_data(*this, make_span(input)),
                   basp::ec::missing_handshake);
 }
 
 CAF_TEST(version mismatch) {
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_header);
   set_input(basp::header{basp::message_type::handshake, 0, 0});
-  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(input))),
+  CAF_CHECK_EQUAL(app.handle_data(*this, make_span(input)),
                   basp::ec::version_mismatch);
 }
 
 CAF_TEST(missing payload in handshake) {
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_header);
   set_input(basp::header{basp::message_type::handshake, 0, basp::version});
-  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(input))),
+  CAF_CHECK_EQUAL(app.handle_data(*this, make_span(input)),
                   basp::ec::missing_payload);
 }
 
@@ -210,9 +210,9 @@ CAF_TEST(invalid handshake) {
   auto payload = to_buf(no_nid, no_ids);
   set_input(basp::header{basp::message_type::handshake,
                          static_cast<uint32_t>(payload.size()), basp::version});
-  REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(input))));
+  REQUIRE_OK(app.handle_data(*this, make_span(input)));
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_payload);
-  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(payload))),
+  CAF_CHECK_EQUAL(app.handle_data(*this, make_span(payload)),
                   basp::ec::invalid_handshake);
 }
 
@@ -222,9 +222,9 @@ CAF_TEST(app identifier mismatch) {
   auto payload = to_buf(mars, wrong_ids);
   set_input(basp::header{basp::message_type::handshake,
                          static_cast<uint32_t>(payload.size()), basp::version});
-  REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(input))));
+  REQUIRE_OK(app.handle_data(*this, make_span(input)));
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_handshake_payload);
-  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(payload))),
+  CAF_CHECK_EQUAL(app.handle_data(*this, make_span(payload)),
                   basp::ec::app_identifiers_mismatch);
 }
 
@@ -237,8 +237,8 @@ CAF_TEST(repeated handshake) {
   auto payload = to_buf(no_nid, no_ids);
   set_input(basp::header{basp::message_type::handshake,
                          static_cast<uint32_t>(payload.size()), basp::version});
-  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(input))), none);
-  CAF_CHECK_EQUAL(app.handle_data(*this, as_bytes(make_span(payload))),
+  CAF_CHECK_EQUAL(app.handle_data(*this, make_span(input)), none);
+  CAF_CHECK_EQUAL(app.handle_data(*this, make_span(payload)),
                   basp::ec::unexpected_handshake);
 }
 
@@ -337,7 +337,7 @@ CAF_TEST(heartbeat message) {
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_header);
   auto bytes = to_bytes(basp::header{basp::message_type::heartbeat, 0, 0});
   set_input(bytes);
-  REQUIRE_OK(app.handle_data(*this, as_bytes(make_span(input))));
+  REQUIRE_OK(app.handle_data(*this, make_span(input)));
   CAF_CHECK_EQUAL(app.state(), basp::connection_state::await_header);
 }
 

--- a/libcaf_net/test/datagram_transport.cpp
+++ b/libcaf_net/test/datagram_transport.cpp
@@ -83,7 +83,7 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
     uint8_t receive_attempts = 0;
     variant<std::pair<size_t, ip_endpoint>, sec> read_ret;
     do {
-      read_ret = read(sock, make_span(buf));
+      read_ret = read(sock, buf);
       if (auto read_res = get_if<std::pair<size_t, ip_endpoint>>(&read_ret)) {
         buf.resize(read_res->first);
       } else if (get<sec>(read_ret) != sec::unavailable_or_would_block) {

--- a/libcaf_net/test/datagram_transport.cpp
+++ b/libcaf_net/test/datagram_transport.cpp
@@ -23,6 +23,7 @@
 #include "caf/net/test/host_fixture.hpp"
 #include "caf/test/dsl.hpp"
 
+#include "caf/binary_serializer.hpp"
 #include "caf/byte.hpp"
 #include "caf/detail/socket_sys_includes.hpp"
 #include "caf/make_actor.hpp"
@@ -33,7 +34,6 @@
 #include "caf/net/make_endpoint_manager.hpp"
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/udp_datagram_socket.hpp"
-#include "caf/serializer_impl.hpp"
 #include "caf/span.hpp"
 
 using namespace caf;
@@ -169,9 +169,9 @@ public:
   static expected<buffer_type> serialize(actor_system& sys,
                                          const type_erased_tuple& x) {
     buffer_type result;
-    serializer_impl<buffer_type> sink{sys, result};
+    binary_serializer sink{sys, result};
     if (auto err = message::save(sink, x))
-      return err;
+      return err.value();
     return result;
   }
 

--- a/libcaf_net/test/endpoint_manager.cpp
+++ b/libcaf_net/test/endpoint_manager.cpp
@@ -94,7 +94,7 @@ public:
 
   template <class Manager>
   bool handle_read_event(Manager&) {
-    auto res = read(handle_, make_span(read_buf_));
+    auto res = read(handle_, read_buf_);
     if (auto num_bytes = get_if<size_t>(&res)) {
       data_->insert(data_->end(), read_buf_.begin(),
                     read_buf_.begin() + *num_bytes);
@@ -109,7 +109,7 @@ public:
       auto& payload = x->payload;
       buf_.insert(buf_.end(), payload.begin(), payload.end());
     }
-    auto res = write(handle_, as_bytes(make_span(buf_)));
+    auto res = write(handle_, buf_);
     if (auto num_bytes = get_if<size_t>(&res)) {
       buf_.erase(buf_.begin(), buf_.begin() + *num_bytes);
       return buf_.size() > 0;
@@ -168,7 +168,7 @@ CAF_TEST(send and receive) {
   auto buf = std::make_shared<std::vector<byte>>();
   auto sockets = unbox(make_stream_socket_pair());
   nonblocking(sockets.second, true);
-  CAF_CHECK_EQUAL(read(sockets.second, make_span(read_buf)),
+  CAF_CHECK_EQUAL(read(sockets.second, read_buf),
                   sec::unavailable_or_would_block);
   auto guard = detail::make_scope_guard([&] { close(sockets.second); });
   auto mgr = make_endpoint_manager(mpx, sys,
@@ -183,7 +183,7 @@ CAF_TEST(send and receive) {
   CAF_CHECK_EQUAL(string_view(reinterpret_cast<char*>(buf->data()),
                               buf->size()),
                   hello_manager);
-  CAF_CHECK_EQUAL(read(sockets.second, make_span(read_buf)), hello_test.size());
+  CAF_CHECK_EQUAL(read(sockets.second, read_buf), hello_test.size());
   CAF_CHECK_EQUAL(string_view(reinterpret_cast<char*>(read_buf.data()),
                               hello_test.size()),
                   hello_test);
@@ -200,7 +200,7 @@ CAF_TEST(resolve and proxy communication) {
   CAF_CHECK_EQUAL(mgr->init(), none);
   CAF_CHECK_EQUAL(mgr->mask(), operation::read_write);
   run();
-  CAF_CHECK_EQUAL(read(sockets.second, make_span(read_buf)), hello_test.size());
+  CAF_CHECK_EQUAL(read(sockets.second, read_buf), hello_test.size());
   mgr->resolve(unbox(make_uri("test:id/42")), self);
   run();
   self->receive(
@@ -211,7 +211,7 @@ CAF_TEST(resolve and proxy communication) {
     after(std::chrono::seconds(0)) >>
       [&] { CAF_FAIL("manager did not respond with a proxy."); });
   run();
-  auto read_res = read(sockets.second, make_span(read_buf));
+  auto read_res = read(sockets.second, read_buf);
   if (!holds_alternative<size_t>(read_res)) {
     CAF_ERROR("read() returned an error: " << sys.render(get<sec>(read_res)));
     return;

--- a/libcaf_net/test/header.cpp
+++ b/libcaf_net/test/header.cpp
@@ -23,7 +23,7 @@
 #include "caf/test/dsl.hpp"
 
 #include "caf/binary_deserializer.hpp"
-#include "caf/serializer_impl.hpp"
+#include "caf/binary_serializer.hpp"
 
 using namespace caf;
 using namespace caf::net;
@@ -32,7 +32,7 @@ CAF_TEST(serialization) {
   basp::header x{basp::message_type::handshake, 42, 4};
   std::vector<byte> buf;
   {
-    serializer_impl<std::vector<byte>> sink{nullptr, buf};
+    binary_serializer sink{nullptr, buf};
     CAF_CHECK_EQUAL(sink(x), none);
   }
   CAF_CHECK_EQUAL(buf.size(), basp::header_size);
@@ -45,7 +45,7 @@ CAF_TEST(serialization) {
     CAF_CHECK_EQUAL(source(y), none);
   }
   CAF_CHECK_EQUAL(x, y);
-  auto z = basp::header::from_bytes(buf);
+  auto z = basp::header::from_bytes(as_bytes(make_span(buf)));
   CAF_CHECK_EQUAL(x, z);
   CAF_CHECK_EQUAL(y, z);
 }

--- a/libcaf_net/test/header.cpp
+++ b/libcaf_net/test/header.cpp
@@ -45,7 +45,7 @@ CAF_TEST(serialization) {
     CAF_CHECK_EQUAL(source(y), none);
   }
   CAF_CHECK_EQUAL(x, y);
-  auto z = basp::header::from_bytes(make_span(buf));
+  auto z = basp::header::from_bytes(buf);
   CAF_CHECK_EQUAL(x, z);
   CAF_CHECK_EQUAL(y, z);
 }

--- a/libcaf_net/test/header.cpp
+++ b/libcaf_net/test/header.cpp
@@ -45,7 +45,7 @@ CAF_TEST(serialization) {
     CAF_CHECK_EQUAL(source(y), none);
   }
   CAF_CHECK_EQUAL(x, y);
-  auto z = basp::header::from_bytes(as_bytes(make_span(buf)));
+  auto z = basp::header::from_bytes(make_span(buf));
   CAF_CHECK_EQUAL(x, z);
   CAF_CHECK_EQUAL(y, z);
 }

--- a/libcaf_net/test/multiplexer.cpp
+++ b/libcaf_net/test/multiplexer.cpp
@@ -72,7 +72,7 @@ public:
   bool handle_write_event() override {
     if (wr_buf_.size() == 0)
       return false;
-    auto res = write(handle(), make_span(wr_buf_));
+    auto res = write(handle(), as_bytes(make_span(wr_buf_)));
     if (auto num_bytes = get_if<size_t>(&res)) {
       CAF_ASSERT(*num_bytes > 0);
       wr_buf_.erase(wr_buf_.begin(), wr_buf_.begin() + *num_bytes);

--- a/libcaf_net/test/multiplexer.cpp
+++ b/libcaf_net/test/multiplexer.cpp
@@ -72,7 +72,7 @@ public:
   bool handle_write_event() override {
     if (wr_buf_.size() == 0)
       return false;
-    auto res = write(handle(), make_span(wr_buf_));
+    auto res = write(handle(), wr_buf_);
     if (auto num_bytes = get_if<size_t>(&res)) {
       CAF_ASSERT(*num_bytes > 0);
       wr_buf_.erase(wr_buf_.begin(), wr_buf_.begin() + *num_bytes);

--- a/libcaf_net/test/multiplexer.cpp
+++ b/libcaf_net/test/multiplexer.cpp
@@ -72,7 +72,7 @@ public:
   bool handle_write_event() override {
     if (wr_buf_.size() == 0)
       return false;
-    auto res = write(handle(), as_bytes(make_span(wr_buf_)));
+    auto res = write(handle(), make_span(wr_buf_));
     if (auto num_bytes = get_if<size_t>(&res)) {
       CAF_ASSERT(*num_bytes > 0);
       wr_buf_.erase(wr_buf_.begin(), wr_buf_.begin() + *num_bytes);

--- a/libcaf_net/test/net/basp/worker.cpp
+++ b/libcaf_net/test/net/basp/worker.cpp
@@ -117,7 +117,7 @@ CAF_TEST(deliver serialized message) {
                         static_cast<uint32_t>(payload.size()),
                         make_message_id().integer_value()};
   CAF_MESSAGE("launch worker");
-  w->launch(last_hop, hdr, as_bytes(make_span(payload)));
+  w->launch(last_hop, hdr, make_span(payload));
   sched.run_once();
   expect((ok_atom), from(_).to(testee));
 }

--- a/libcaf_net/test/net/basp/worker.cpp
+++ b/libcaf_net/test/net/basp/worker.cpp
@@ -117,7 +117,7 @@ CAF_TEST(deliver serialized message) {
                         static_cast<uint32_t>(payload.size()),
                         make_message_id().integer_value()};
   CAF_MESSAGE("launch worker");
-  w->launch(last_hop, hdr, make_span(payload));
+  w->launch(last_hop, hdr, payload);
   sched.run_once();
   expect((ok_atom), from(_).to(testee));
 }

--- a/libcaf_net/test/net/basp/worker.cpp
+++ b/libcaf_net/test/net/basp/worker.cpp
@@ -25,10 +25,10 @@
 #include "caf/actor_cast.hpp"
 #include "caf/actor_control_block.hpp"
 #include "caf/actor_system.hpp"
+#include "caf/binary_serializer.hpp"
 #include "caf/make_actor.hpp"
 #include "caf/net/basp/message_queue.hpp"
 #include "caf/proxy_registry.hpp"
-#include "caf/serializer_impl.hpp"
 
 using namespace caf;
 
@@ -109,7 +109,7 @@ CAF_TEST(deliver serialized message) {
   CAF_MESSAGE("create a fake message + BASP header");
   std::vector<byte> payload;
   std::vector<strong_actor_ptr> stages;
-  serializer_impl<std::vector<byte>> sink{sys, payload};
+  binary_serializer sink{sys, payload};
   if (auto err = sink(node_id{}, self->id(), testee.id(), stages,
                       make_message(ok_atom::value)))
     CAF_FAIL("unable to serialize message: " << sys.render(err));
@@ -117,7 +117,7 @@ CAF_TEST(deliver serialized message) {
                         static_cast<uint32_t>(payload.size()),
                         make_message_id().integer_value()};
   CAF_MESSAGE("launch worker");
-  w->launch(last_hop, hdr, payload);
+  w->launch(last_hop, hdr, as_bytes(make_span(payload)));
   sched.run_once();
   expect((ok_atom), from(_).to(testee));
 }

--- a/libcaf_net/test/pipe_socket.cpp
+++ b/libcaf_net/test/pipe_socket.cpp
@@ -26,7 +26,6 @@
 #include <vector>
 
 #include "caf/byte.hpp"
-#include "caf/span.hpp"
 
 using namespace caf;
 using namespace caf::net;
@@ -41,8 +40,8 @@ CAF_TEST(send and receive) {
   pipe_socket rd_sock;
   pipe_socket wr_sock;
   std::tie(rd_sock, wr_sock) = unbox(make_pipe());
-  CAF_CHECK_EQUAL(write(wr_sock, make_span(send_buf)), send_buf.size());
-  CAF_CHECK_EQUAL(read(rd_sock, make_span(receive_buf)), send_buf.size());
+  CAF_CHECK_EQUAL(write(wr_sock, send_buf), send_buf.size());
+  CAF_CHECK_EQUAL(read(rd_sock, receive_buf), send_buf.size());
   CAF_CHECK(std::equal(send_buf.begin(), send_buf.end(), receive_buf.begin()));
 }
 

--- a/libcaf_net/test/pipe_socket.cpp
+++ b/libcaf_net/test/pipe_socket.cpp
@@ -41,7 +41,8 @@ CAF_TEST(send and receive) {
   pipe_socket rd_sock;
   pipe_socket wr_sock;
   std::tie(rd_sock, wr_sock) = unbox(make_pipe());
-  CAF_CHECK_EQUAL(write(wr_sock, make_span(send_buf)), send_buf.size());
+  CAF_CHECK_EQUAL(write(wr_sock, as_bytes(make_span(send_buf))),
+                  send_buf.size());
   CAF_CHECK_EQUAL(read(rd_sock, make_span(receive_buf)), send_buf.size());
   CAF_CHECK(std::equal(send_buf.begin(), send_buf.end(), receive_buf.begin()));
 }

--- a/libcaf_net/test/pipe_socket.cpp
+++ b/libcaf_net/test/pipe_socket.cpp
@@ -41,8 +41,7 @@ CAF_TEST(send and receive) {
   pipe_socket rd_sock;
   pipe_socket wr_sock;
   std::tie(rd_sock, wr_sock) = unbox(make_pipe());
-  CAF_CHECK_EQUAL(write(wr_sock, as_bytes(make_span(send_buf))),
-                  send_buf.size());
+  CAF_CHECK_EQUAL(write(wr_sock, make_span(send_buf)), send_buf.size());
   CAF_CHECK_EQUAL(read(rd_sock, make_span(receive_buf)), send_buf.size());
   CAF_CHECK(std::equal(send_buf.begin(), send_buf.end(), receive_buf.begin()));
 }

--- a/libcaf_net/test/stream_application.cpp
+++ b/libcaf_net/test/stream_application.cpp
@@ -82,7 +82,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
   template <class... Ts>
   buffer_type to_buf(const Ts&... xs) {
     buffer_type buf;
-    serializer_impl<buffer_type> sink{system(), buf};
+    binary_serializer sink{system(), buf};
     REQUIRE_OK(sink(xs...));
     return buf;
   }
@@ -90,7 +90,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
   template <class... Ts>
   void mock(const Ts&... xs) {
     auto buf = to_buf(xs...);
-    if (fetch_size(write(sock, make_span(buf))) != buf.size())
+    if (fetch_size(write(sock, as_bytes(make_span(buf)))) != buf.size())
       CAF_FAIL("unable to write " << buf.size() << " bytes");
     run();
   }
@@ -103,7 +103,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
                       static_cast<uint32_t>(payload.size()), basp::version});
     CAF_CHECK_EQUAL(app->state(),
                     basp::connection_state::await_handshake_payload);
-    write(sock, make_span(payload));
+    write(sock, as_bytes(make_span(payload)));
     run();
   }
 
@@ -111,7 +111,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
     buffer_type buf(basp::header_size);
     if (fetch_size(read(sock, make_span(buf))) != basp::header_size)
       CAF_FAIL("unable to read " << basp::header_size << " bytes");
-    auto hdr = basp::header::from_bytes(buf);
+    auto hdr = basp::header::from_bytes(as_bytes(make_span(buf)));
     if (hdr.type != basp::message_type::handshake || hdr.payload_len == 0
         || hdr.operation_data != basp::version)
       CAF_FAIL("invalid handshake header");
@@ -149,7 +149,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
                       std::tuple<unit_t>>::value) {                            \
       auto payload = to_buf(__VA_ARGS__);                                      \
       mock(basp::header{kind, static_cast<uint32_t>(payload.size()), op});     \
-      write(sock, make_span(payload));                                         \
+      write(sock, as_bytes(make_span(payload)));                               \
     } else {                                                                   \
       mock(basp::header{kind, 0, op});                                         \
     }                                                                          \
@@ -162,7 +162,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
     buffer_type buf(basp::header_size);                                        \
     if (fetch_size(read(sock, make_span(buf))) != basp::header_size)           \
       CAF_FAIL("unable to read " << basp::header_size << " bytes");            \
-    auto hdr = basp::header::from_bytes(buf);                                  \
+    auto hdr = basp::header::from_bytes(as_bytes(make_span(buf)));             \
     CAF_CHECK_EQUAL(hdr.type, msg_type);                                       \
     CAF_CHECK_EQUAL(hdr.operation_data, op_data);                              \
     if (!std::is_same<decltype(std::make_tuple(__VA_ARGS__)),                  \

--- a/libcaf_net/test/stream_application.cpp
+++ b/libcaf_net/test/stream_application.cpp
@@ -90,7 +90,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
   template <class... Ts>
   void mock(const Ts&... xs) {
     auto buf = to_buf(xs...);
-    if (fetch_size(write(sock, as_bytes(make_span(buf)))) != buf.size())
+    if (fetch_size(write(sock, make_span(buf))) != buf.size())
       CAF_FAIL("unable to write " << buf.size() << " bytes");
     run();
   }
@@ -103,7 +103,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
                       static_cast<uint32_t>(payload.size()), basp::version});
     CAF_CHECK_EQUAL(app->state(),
                     basp::connection_state::await_handshake_payload);
-    write(sock, as_bytes(make_span(payload)));
+    write(sock, make_span(payload));
     run();
   }
 
@@ -111,7 +111,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
     buffer_type buf(basp::header_size);
     if (fetch_size(read(sock, make_span(buf))) != basp::header_size)
       CAF_FAIL("unable to read " << basp::header_size << " bytes");
-    auto hdr = basp::header::from_bytes(as_bytes(make_span(buf)));
+    auto hdr = basp::header::from_bytes(make_span(buf));
     if (hdr.type != basp::message_type::handshake || hdr.payload_len == 0
         || hdr.operation_data != basp::version)
       CAF_FAIL("invalid handshake header");
@@ -149,7 +149,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
                       std::tuple<unit_t>>::value) {                            \
       auto payload = to_buf(__VA_ARGS__);                                      \
       mock(basp::header{kind, static_cast<uint32_t>(payload.size()), op});     \
-      write(sock, as_bytes(make_span(payload)));                               \
+      write(sock, make_span(payload));                                         \
     } else {                                                                   \
       mock(basp::header{kind, 0, op});                                         \
     }                                                                          \
@@ -162,7 +162,7 @@ struct fixture : host_fixture, test_coordinator_fixture<config> {
     buffer_type buf(basp::header_size);                                        \
     if (fetch_size(read(sock, make_span(buf))) != basp::header_size)           \
       CAF_FAIL("unable to read " << basp::header_size << " bytes");            \
-    auto hdr = basp::header::from_bytes(as_bytes(make_span(buf)));             \
+    auto hdr = basp::header::from_bytes(make_span(buf));                       \
     CAF_CHECK_EQUAL(hdr.type, msg_type);                                       \
     CAF_CHECK_EQUAL(hdr.operation_data, op_data);                              \
     if (!std::is_same<decltype(std::make_tuple(__VA_ARGS__)),                  \

--- a/libcaf_net/test/stream_socket.cpp
+++ b/libcaf_net/test/stream_socket.cpp
@@ -74,31 +74,29 @@ struct fixture : host_fixture {
 CAF_TEST_FIXTURE_SCOPE(network_socket_tests, fixture)
 
 CAF_TEST(read on empty sockets) {
-  CAF_CHECK_EQUAL(read(first, make_span(rd_buf)),
-                  sec::unavailable_or_would_block);
-  CAF_CHECK_EQUAL(read(second, make_span(rd_buf)),
-                  sec::unavailable_or_would_block);
+  CAF_CHECK_EQUAL(read(first, rd_buf), sec::unavailable_or_would_block);
+  CAF_CHECK_EQUAL(read(second, rd_buf), sec::unavailable_or_would_block);
 }
 
 CAF_TEST(transfer data from first to second socket) {
   std::vector<byte> wr_buf{1_b, 2_b, 4_b, 8_b, 16_b, 32_b, 64_b};
   CAF_MESSAGE("transfer data from first to second socket");
-  CAF_CHECK_EQUAL(write(first, make_span(wr_buf)), wr_buf.size());
-  CAF_CHECK_EQUAL(read(second, make_span(rd_buf)), wr_buf.size());
+  CAF_CHECK_EQUAL(write(first, wr_buf), wr_buf.size());
+  CAF_CHECK_EQUAL(read(second, rd_buf), wr_buf.size());
   CAF_CHECK(std::equal(wr_buf.begin(), wr_buf.end(), rd_buf.begin()));
   rd_buf.assign(rd_buf.size(), byte(0));
 }
 
 CAF_TEST(transfer data from second to first socket) {
   std::vector<byte> wr_buf{1_b, 2_b, 4_b, 8_b, 16_b, 32_b, 64_b};
-  CAF_CHECK_EQUAL(write(second, make_span(wr_buf)), wr_buf.size());
-  CAF_CHECK_EQUAL(read(first, make_span(rd_buf)), wr_buf.size());
+  CAF_CHECK_EQUAL(write(second, wr_buf), wr_buf.size());
+  CAF_CHECK_EQUAL(read(first, rd_buf), wr_buf.size());
   CAF_CHECK(std::equal(wr_buf.begin(), wr_buf.end(), rd_buf.begin()));
 }
 
 CAF_TEST(shut down first socket and observe shutdown on the second one) {
   close(first);
-  CAF_CHECK_EQUAL(read(second, make_span(rd_buf)), sec::socket_disconnected);
+  CAF_CHECK_EQUAL(read(second, rd_buf), sec::socket_disconnected);
   first.id = invalid_socket_id;
 }
 
@@ -110,7 +108,7 @@ CAF_TEST(transfer data using multiple buffers) {
   full_buf.insert(full_buf.end(), wr_buf_2.begin(), wr_buf_2.end());
   CAF_CHECK_EQUAL(write(second, {make_span(wr_buf_1), make_span(wr_buf_2)}),
                   full_buf.size());
-  CAF_CHECK_EQUAL(read(first, make_span(rd_buf)), full_buf.size());
+  CAF_CHECK_EQUAL(read(first, rd_buf), full_buf.size());
   CAF_CHECK(std::equal(full_buf.begin(), full_buf.end(), rd_buf.begin()));
 }
 

--- a/libcaf_net/test/stream_socket.cpp
+++ b/libcaf_net/test/stream_socket.cpp
@@ -83,7 +83,7 @@ CAF_TEST(read on empty sockets) {
 CAF_TEST(transfer data from first to second socket) {
   std::vector<byte> wr_buf{1_b, 2_b, 4_b, 8_b, 16_b, 32_b, 64_b};
   CAF_MESSAGE("transfer data from first to second socket");
-  CAF_CHECK_EQUAL(write(first, as_bytes(make_span(wr_buf))), wr_buf.size());
+  CAF_CHECK_EQUAL(write(first, make_span(wr_buf)), wr_buf.size());
   CAF_CHECK_EQUAL(read(second, make_span(rd_buf)), wr_buf.size());
   CAF_CHECK(std::equal(wr_buf.begin(), wr_buf.end(), rd_buf.begin()));
   rd_buf.assign(rd_buf.size(), byte(0));
@@ -91,7 +91,7 @@ CAF_TEST(transfer data from first to second socket) {
 
 CAF_TEST(transfer data from second to first socket) {
   std::vector<byte> wr_buf{1_b, 2_b, 4_b, 8_b, 16_b, 32_b, 64_b};
-  CAF_CHECK_EQUAL(write(second, as_bytes(make_span(wr_buf))), wr_buf.size());
+  CAF_CHECK_EQUAL(write(second, make_span(wr_buf)), wr_buf.size());
   CAF_CHECK_EQUAL(read(first, make_span(rd_buf)), wr_buf.size());
   CAF_CHECK(std::equal(wr_buf.begin(), wr_buf.end(), rd_buf.begin()));
 }
@@ -108,8 +108,7 @@ CAF_TEST(transfer data using multiple buffers) {
   std::vector<byte> full_buf;
   full_buf.insert(full_buf.end(), wr_buf_1.begin(), wr_buf_1.end());
   full_buf.insert(full_buf.end(), wr_buf_2.begin(), wr_buf_2.end());
-  CAF_CHECK_EQUAL(write(second, {as_bytes(make_span(wr_buf_1)),
-                                 as_bytes(make_span(wr_buf_2))}),
+  CAF_CHECK_EQUAL(write(second, {make_span(wr_buf_1), make_span(wr_buf_2)}),
                   full_buf.size());
   CAF_CHECK_EQUAL(read(first, make_span(rd_buf)), full_buf.size());
   CAF_CHECK(std::equal(full_buf.begin(), full_buf.end(), rd_buf.begin()));

--- a/libcaf_net/test/stream_socket.cpp
+++ b/libcaf_net/test/stream_socket.cpp
@@ -83,7 +83,7 @@ CAF_TEST(read on empty sockets) {
 CAF_TEST(transfer data from first to second socket) {
   std::vector<byte> wr_buf{1_b, 2_b, 4_b, 8_b, 16_b, 32_b, 64_b};
   CAF_MESSAGE("transfer data from first to second socket");
-  CAF_CHECK_EQUAL(write(first, make_span(wr_buf)), wr_buf.size());
+  CAF_CHECK_EQUAL(write(first, as_bytes(make_span(wr_buf))), wr_buf.size());
   CAF_CHECK_EQUAL(read(second, make_span(rd_buf)), wr_buf.size());
   CAF_CHECK(std::equal(wr_buf.begin(), wr_buf.end(), rd_buf.begin()));
   rd_buf.assign(rd_buf.size(), byte(0));
@@ -91,7 +91,7 @@ CAF_TEST(transfer data from first to second socket) {
 
 CAF_TEST(transfer data from second to first socket) {
   std::vector<byte> wr_buf{1_b, 2_b, 4_b, 8_b, 16_b, 32_b, 64_b};
-  CAF_CHECK_EQUAL(write(second, make_span(wr_buf)), wr_buf.size());
+  CAF_CHECK_EQUAL(write(second, as_bytes(make_span(wr_buf))), wr_buf.size());
   CAF_CHECK_EQUAL(read(first, make_span(rd_buf)), wr_buf.size());
   CAF_CHECK(std::equal(wr_buf.begin(), wr_buf.end(), rd_buf.begin()));
 }
@@ -108,7 +108,8 @@ CAF_TEST(transfer data using multiple buffers) {
   std::vector<byte> full_buf;
   full_buf.insert(full_buf.end(), wr_buf_1.begin(), wr_buf_1.end());
   full_buf.insert(full_buf.end(), wr_buf_2.begin(), wr_buf_2.end());
-  CAF_CHECK_EQUAL(write(second, {make_span(wr_buf_1), make_span(wr_buf_2)}),
+  CAF_CHECK_EQUAL(write(second, {as_bytes(make_span(wr_buf_1)),
+                                 as_bytes(make_span(wr_buf_2))}),
                   full_buf.size());
   CAF_CHECK_EQUAL(read(first, make_span(rd_buf)), full_buf.size());
   CAF_CHECK(std::equal(full_buf.begin(), full_buf.end(), rd_buf.begin()));

--- a/libcaf_net/test/stream_transport.cpp
+++ b/libcaf_net/test/stream_transport.cpp
@@ -194,7 +194,7 @@ CAF_TEST(resolve and proxy communication) {
     after(std::chrono::seconds(0)) >>
       [&] { CAF_FAIL("manager did not respond with a proxy."); });
   run();
-  auto read_res = read(recv_socket_guard.socket(), make_span(recv_buf));
+  auto read_res = read(recv_socket_guard.socket(), recv_buf);
   if (!holds_alternative<size_t>(read_res))
     CAF_FAIL("read() returned an error: " << sys.render(get<sec>(read_res)));
   recv_buf.resize(get<size_t>(read_res));

--- a/libcaf_net/test/stream_transport.cpp
+++ b/libcaf_net/test/stream_transport.cpp
@@ -24,6 +24,7 @@
 #include "caf/test/dsl.hpp"
 
 #include "caf/binary_deserializer.hpp"
+#include "caf/binary_serializer.hpp"
 #include "caf/byte.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/make_actor.hpp"
@@ -34,7 +35,6 @@
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/socket_guard.hpp"
 #include "caf/net/stream_socket.hpp"
-#include "caf/serializer_impl.hpp"
 #include "caf/span.hpp"
 
 using namespace caf;
@@ -140,9 +140,9 @@ public:
   static expected<buffer_type> serialize(actor_system& sys,
                                          const type_erased_tuple& x) {
     buffer_type result;
-    serializer_impl<buffer_type> sink{sys, result};
+    binary_serializer sink{sys, result};
     if (auto err = message::save(sink, x))
-      return err;
+      return err.value();
     return result;
   }
 

--- a/libcaf_net/test/string_application.cpp
+++ b/libcaf_net/test/string_application.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "caf/binary_deserializer.hpp"
+#include "caf/binary_serializer.hpp"
 #include "caf/byte.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/make_actor.hpp"
@@ -34,7 +35,6 @@
 #include "caf/net/make_endpoint_manager.hpp"
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/stream_socket.hpp"
-#include "caf/serializer_impl.hpp"
 #include "caf/span.hpp"
 
 using namespace caf;
@@ -105,18 +105,19 @@ public:
     if (ptr->msg == nullptr)
       return;
     auto header_buf = parent.next_header_buffer();
-    serializer_impl<buffer_type> sink{sys_, header_buf};
+    binary_serializer sink{sys_, header_buf};
     header_type header{static_cast<uint32_t>(ptr->payload.size())};
-    sink(header);
+    if (auto err = sink(header))
+      CAF_FAIL("serializing failed: " << err);
     parent.write_packet(header_buf, ptr->payload);
   }
 
   static expected<std::vector<byte>> serialize(actor_system& sys,
                                                const type_erased_tuple& x) {
     std::vector<byte> result;
-    serializer_impl<std::vector<byte>> sink{sys, result};
+    binary_serializer sink{sys, result};
     if (auto err = message::save(sink, x))
-      return err;
+      return err.value();
     return result;
   }
 

--- a/libcaf_net/test/string_application.cpp
+++ b/libcaf_net/test/string_application.cpp
@@ -153,7 +153,8 @@ public:
       if (data.size() != sizeof(header_type))
         CAF_FAIL("");
       binary_deserializer source{nullptr, data};
-      source(header_);
+      if (auto err = source(header_))
+        CAF_FAIL("serializing failed: " << err);
       if (header_.payload == 0)
         Base::handle_packet(parent, header_, span<const byte>{});
       else
@@ -215,7 +216,7 @@ CAF_TEST(receive) {
   auto buf = std::make_shared<std::vector<byte>>();
   auto sockets = unbox(make_stream_socket_pair());
   nonblocking(sockets.second, true);
-  CAF_CHECK_EQUAL(read(sockets.second, make_span(read_buf)),
+  CAF_CHECK_EQUAL(read(sockets.second, read_buf),
                   sec::unavailable_or_would_block);
   CAF_MESSAGE("adding both endpoint managers");
   auto mgr1 = make_endpoint_manager(mpx, sys,

--- a/libcaf_net/test/transport_worker.cpp
+++ b/libcaf_net/test/transport_worker.cpp
@@ -202,9 +202,7 @@ CAF_TEST(write_message) {
   auto msg = make_message();
   auto elem = make_mailbox_element(strong_actor, make_message_id(12345), stack,
                                    msg);
-  auto test_span = make_span(reinterpret_cast<byte*>(
-                               const_cast<char*>(hello_test.data())),
-                             hello_test.size());
+  auto test_span = as_bytes(make_span(hello_test));
   std::vector<byte> payload(test_span.begin(), test_span.end());
   using message_type = endpoint_manager_queue::message;
   auto message = detail::make_unique<message_type>(std::move(elem), nullptr,

--- a/libcaf_net/test/transport_worker.cpp
+++ b/libcaf_net/test/transport_worker.cpp
@@ -23,13 +23,13 @@
 #include "caf/net/test/host_fixture.hpp"
 #include "caf/test/dsl.hpp"
 
+#include "caf/binary_serializer.hpp"
 #include "caf/byte.hpp"
 #include "caf/detail/scope_guard.hpp"
 #include "caf/ip_endpoint.hpp"
 #include "caf/make_actor.hpp"
 #include "caf/net/actor_proxy_impl.hpp"
 #include "caf/net/multiplexer.hpp"
-#include "caf/serializer_impl.hpp"
 #include "caf/span.hpp"
 
 using namespace caf;
@@ -105,9 +105,9 @@ public:
   static expected<std::vector<byte>> serialize(actor_system& sys,
                                                const type_erased_tuple& x) {
     std::vector<byte> result;
-    serializer_impl<std::vector<byte>> sink{sys, result};
+    binary_serializer sink{sys, result};
     if (auto err = message::save(sink, x))
-      return err;
+      return err.value();
     return result;
   }
 

--- a/libcaf_net/test/transport_worker_dispatcher.cpp
+++ b/libcaf_net/test/transport_worker_dispatcher.cpp
@@ -247,7 +247,7 @@ struct fixture : host_fixture {
 };
 
 #define CHECK_HANDLE_DATA(testcase)                                            \
-  dispatcher.handle_data(dummy, span<byte>{}, testcase.ep);                    \
+  dispatcher.handle_data(dummy, span<const byte>{}, testcase.ep);              \
   CAF_CHECK_EQUAL(buf->size(), 1u);                                            \
   CAF_CHECK_EQUAL(static_cast<byte>(testcase.worker_id), buf->at(0));          \
   buf->clear();

--- a/libcaf_net/test/udp_datagram_socket.cpp
+++ b/libcaf_net/test/udp_datagram_socket.cpp
@@ -69,7 +69,7 @@ error read_from_socket(udp_datagram_socket sock, std::vector<byte>& buf) {
   uint8_t receive_attempts = 0;
   variant<std::pair<size_t, ip_endpoint>, sec> read_ret;
   do {
-    read_ret = read(sock, make_span(buf));
+    read_ret = read(sock, buf);
     if (auto read_res = get_if<std::pair<size_t, ip_endpoint>>(&read_ret)) {
       buf.resize(read_res->first);
     } else if (get<sec>(read_ret) != sec::unavailable_or_would_block) {
@@ -106,8 +106,7 @@ CAF_TEST_FIXTURE_SCOPE(udp_datagram_socket_test, fixture)
 CAF_TEST(read / write using span<byte>) {
   if (auto err = nonblocking(socket_cast<net::socket>(receive_socket), true))
     CAF_FAIL("setting socket to nonblocking failed: " << err);
-  CAF_CHECK_EQUAL(read(receive_socket, make_span(buf)),
-                  sec::unavailable_or_would_block);
+  CAF_CHECK_EQUAL(read(receive_socket, buf), sec::unavailable_or_would_block);
   CAF_MESSAGE("sending data to " << to_string(ep));
   CAF_CHECK_EQUAL(write(send_socket, as_bytes(make_span(hello_test)), ep),
                   hello_test.size());
@@ -127,7 +126,7 @@ CAF_TEST(read / write using span<std::vector<byte>*>) {
   std::vector<byte> payload_buf(bytes.begin(), bytes.end());
   auto packet_size = hdr_buf.size() + payload_buf.size();
   std::vector<std::vector<byte>*> bufs{&hdr_buf, &payload_buf};
-  CAF_CHECK_EQUAL(write(send_socket, make_span(bufs), ep), packet_size);
+  CAF_CHECK_EQUAL(write(send_socket, bufs, ep), packet_size);
   // receive both as one single packet.
   buf.resize(packet_size);
   CAF_CHECK_EQUAL(read_from_socket(receive_socket, buf), none);


### PR DESCRIPTION
This PR refactors the incubator code base to use the new `binary_serializer`.