### PR TITLE
Add nodelay opt

### DIFF
--- a/libcaf_net/caf/net/stream_transport.hpp
+++ b/libcaf_net/caf/net/stream_transport.hpp
@@ -67,7 +67,8 @@ public:
       collected_(0),
       max_(1024),
       rd_flag_(net::receive_policy_flag::exactly) {
-    // nop
+    CAF_ASSERT(handle != invalid_socket);
+    nodelay(handle, true);
   }
 
   // -- member functions -------------------------------------------------------


### PR DESCRIPTION
We forgot to set the `TCP_NODELAY` socket option and this PR fixes that.