### PR TITLE
Add serializer worker

### DIFF
--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -44,6 +44,7 @@ set(CAF_NET_SOURCES
   src/defaults.cpp
   src/message_queue.cpp
   src/worker.cpp
+  src/serializing_worker.cpp
 )
 
 # -- list cpp files for caf-net-test ------------------------------------------

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -45,6 +45,7 @@ set(CAF_NET_SOURCES
   src/message_queue.cpp
   src/worker.cpp
   src/serializing_worker.cpp
+  src/outgoing_message_queue.cpp
 )
 
 # -- list cpp files for caf-net-test ------------------------------------------

--- a/libcaf_net/caf/net/actor_proxy_impl.hpp
+++ b/libcaf_net/caf/net/actor_proxy_impl.hpp
@@ -30,7 +30,7 @@ public:
 
   actor_proxy_impl(actor_config& cfg, endpoint_manager_ptr dst);
 
-  ~actor_proxy_impl() override;
+  ~actor_proxy_impl() override = default;
 
   void enqueue(mailbox_element_ptr what, execution_unit* context) override;
 

--- a/libcaf_net/caf/net/backend/test.hpp
+++ b/libcaf_net/caf/net/backend/test.hpp
@@ -74,8 +74,6 @@ private:
   std::map<node_id, peer_entry> peers_;
 
   proxy_registry proxies_;
-
-  detail::worker_hub<serializing_worker> hub_;
 };
 
 } // namespace caf::net::backend

--- a/libcaf_net/caf/net/backend/test.hpp
+++ b/libcaf_net/caf/net/backend/test.hpp
@@ -74,6 +74,8 @@ private:
   std::map<node_id, peer_entry> peers_;
 
   proxy_registry proxies_;
+
+  detail::worker_hub<serializing_worker> hub_;
 };
 
 } // namespace caf::net::backend

--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -80,6 +80,7 @@ public:
       manager_ = &parent.manager();
     auto workers = get_or(system_->config(), "middleman.workers",
                           defaults::middleman::workers);
+    CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for deserializing");
     for (size_t i = 0; i < workers; ++i)
       hub_->add_new_worker(*queue_, proxies_);
     // Write handshake.

--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -125,8 +125,8 @@ public:
     // nop
   }
 
-  static expected<buffer_type> serialize(actor_system& sys,
-                                         const type_erased_tuple& x);
+  static error serialize(actor_system& sys, const type_erased_tuple& x,
+                         buffer_type& buf);
 
   // -- utility functions ------------------------------------------------------
 

--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -75,9 +75,8 @@ public:
     system_ = &parent.system();
     executor_.system_ptr(system_);
     executor_.proxy_registry_ptr(&proxies_);
-    // TODO: use `if constexpr` when switching to C++17.
     // Allow unit tests to run the application without endpoint manager.
-    if (!std::is_base_of<test_tag, Parent>::value)
+    if constexpr (!std::is_base_of<test_tag, Parent>::value)
       manager_ = &parent.manager();
     auto workers = get_or(system_->config(), "middleman.workers",
                           defaults::middleman::workers);

--- a/libcaf_net/caf/net/basp/worker.hpp
+++ b/libcaf_net/caf/net/basp/worker.hpp
@@ -55,14 +55,15 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   /// Only the ::worker_hub has access to the construtor.
-  worker(hub_type& hub, message_queue& queue, proxy_registry& proxies);
+  worker(hub_type& hub, actor_system& sys);
 
   ~worker() override;
 
   // -- management -------------------------------------------------------------
 
   void launch(const node_id& last_hop, const basp::header& hdr,
-              span<const byte> payload);
+              span<const byte> payload, message_queue& queue,
+              proxy_registry& proxies);
 
   // -- implementation of resumable --------------------------------------------
 

--- a/libcaf_net/caf/net/datagram_transport.hpp
+++ b/libcaf_net/caf/net/datagram_transport.hpp
@@ -178,6 +178,7 @@ private:
              && this->payload_bufs_.size() < this->payload_bufs_.capacity();
            ++it) {
         it->clear();
+        const std::lock_guard<std::mutex> lock(*this->payload_buffer_lock_);
         this->payload_bufs_.emplace_back(std::move(*it));
       }
       packet_queue_.pop_front();

--- a/libcaf_net/caf/net/defaults.hpp
+++ b/libcaf_net/caf/net/defaults.hpp
@@ -20,16 +20,18 @@
 
 #include <cstddef>
 
+#include "caf/detail/net_export.hpp"
+
 // -- hard-coded default values for various CAF options ------------------------
 
 namespace caf::defaults::middleman {
 
-extern const size_t serializing_workers;
+CAF_NET_EXPORT extern const size_t serializing_workers;
 
 /// Maximum number of cached buffers for sending payloads.
-extern const size_t max_payload_buffers;
+CAF_NET_EXPORT extern const size_t max_payload_buffers;
 
 /// Maximum number of cached buffers for sending headers.
-extern const size_t max_header_buffers;
+CAF_NET_EXPORT extern const size_t max_header_buffers;
 
 } // namespace caf::defaults::middleman

--- a/libcaf_net/caf/net/defaults.hpp
+++ b/libcaf_net/caf/net/defaults.hpp
@@ -24,6 +24,8 @@
 
 namespace caf::defaults::middleman {
 
+extern const size_t serializing_workers;
+
 /// Maximum number of cached buffers for sending payloads.
 extern const size_t max_payload_buffers;
 

--- a/libcaf_net/caf/net/doorman.hpp
+++ b/libcaf_net/caf/net/doorman.hpp
@@ -46,9 +46,8 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  explicit doorman(net::tcp_accept_socket acceptor, factory_type factory,
-                   hub_type& hub)
-    : acceptor_(acceptor), factory_(std::move(factory)), hub_(hub) {
+  explicit doorman(net::tcp_accept_socket acceptor, factory_type factory)
+    : acceptor_(acceptor), factory_(std::move(factory)) {
     // nop
   }
 
@@ -82,8 +81,8 @@ public:
     }
     auto child = make_endpoint_manager(mpx, parent.system(),
                                        stream_transport<
-                                         application_type>{*x, factory_.make()},
-                                       hub_);
+                                         application_type>{*x,
+                                                           factory_.make()});
     if (auto err = child->init())
       return false;
     return true;
@@ -131,8 +130,6 @@ private:
   net::tcp_accept_socket acceptor_;
 
   factory_type factory_;
-
-  hub_type& hub_;
 };
 
 } // namespace caf::net

--- a/libcaf_net/caf/net/doorman.hpp
+++ b/libcaf_net/caf/net/doorman.hpp
@@ -42,8 +42,6 @@ public:
 
   using application_type = typename Factory::application_type;
 
-  using hub_type = detail::worker_hub<serializing_worker>;
-
   // -- constructors, destructors, and assignment operators --------------------
 
   explicit doorman(net::tcp_accept_socket acceptor, factory_type factory)
@@ -61,7 +59,6 @@ public:
 
   template <class Parent>
   error init(Parent& parent) {
-    // TODO: is initializing application factory nessecary?
     if (auto err = factory_.init(parent))
       return err;
     return none;
@@ -124,6 +121,11 @@ public:
 
   void handle_error(sec err) {
     CAF_LOG_ERROR("doorman encounterd error: " << err);
+  }
+
+  std::vector<byte> next_payload_buffer() {
+    CAF_LOG_ERROR("doorman called for next_payload_buffer");
+    return {};
   }
 
 private:

--- a/libcaf_net/caf/net/doorman.hpp
+++ b/libcaf_net/caf/net/doorman.hpp
@@ -42,10 +42,13 @@ public:
 
   using application_type = typename Factory::application_type;
 
+  using hub_type = detail::worker_hub<serializing_worker>;
+
   // -- constructors, destructors, and assignment operators --------------------
 
-  explicit doorman(net::tcp_accept_socket acceptor, factory_type factory)
-    : acceptor_(acceptor), factory_(std::move(factory)) {
+  explicit doorman(net::tcp_accept_socket acceptor, factory_type factory,
+                   hub_type& hub)
+    : acceptor_(acceptor), factory_(std::move(factory)), hub_(hub) {
     // nop
   }
 
@@ -79,8 +82,8 @@ public:
     }
     auto child = make_endpoint_manager(mpx, parent.system(),
                                        stream_transport<
-                                         application_type>{*x,
-                                                           factory_.make()});
+                                         application_type>{*x, factory_.make()},
+                                       hub_);
     if (auto err = child->init())
       return false;
     return true;
@@ -128,6 +131,8 @@ private:
   net::tcp_accept_socket acceptor_;
 
   factory_type factory_;
+
+  hub_type& hub_;
 };
 
 } // namespace caf::net

--- a/libcaf_net/caf/net/endpoint_manager.hpp
+++ b/libcaf_net/caf/net/endpoint_manager.hpp
@@ -26,12 +26,14 @@
 #include "caf/actor_clock.hpp"
 #include "caf/byte.hpp"
 #include "caf/detail/net_export.hpp"
+#include "caf/detail/worker_hub.hpp"
 #include "caf/fwd.hpp"
 #include "caf/intrusive/drr_queue.hpp"
 #include "caf/intrusive/fifo_inbox.hpp"
 #include "caf/intrusive/singly_linked.hpp"
 #include "caf/mailbox_element.hpp"
 #include "caf/net/endpoint_manager_queue.hpp"
+#include "caf/net/serializing_worker.hpp"
 #include "caf/net/socket_manager.hpp"
 #include "caf/variant.hpp"
 
@@ -40,9 +42,13 @@ namespace caf::net {
 /// Manages a communication endpoint.
 class CAF_NET_EXPORT endpoint_manager : public socket_manager {
 public:
+  friend serializing_worker;
+
   // -- member types -----------------------------------------------------------
 
   using super = socket_manager;
+
+  using hub_type = detail::worker_hub<serializing_worker>;
 
   /// Represents either an error or a serialized payload.
   using maybe_buffer = expected<std::vector<byte>>;
@@ -100,6 +106,8 @@ protected:
 
   /// Stores a proxy for interacting with the actor clock.
   actor timeout_proxy_;
+
+  detail::worker_hub<serializing_worker> hub_;
 };
 
 using endpoint_manager_ptr = intrusive_ptr<endpoint_manager>;

--- a/libcaf_net/caf/net/endpoint_manager.hpp
+++ b/libcaf_net/caf/net/endpoint_manager.hpp
@@ -42,13 +42,15 @@ namespace caf::net {
 /// Manages a communication endpoint.
 class CAF_NET_EXPORT endpoint_manager : public socket_manager {
 public:
-  friend serializing_worker;
+  friend serializing_worker<endpoint_manager>;
 
   // -- member types -----------------------------------------------------------
 
   using super = socket_manager;
 
-  using hub_type = detail::worker_hub<serializing_worker>;
+  using worker_type = serializing_worker<endpoint_manager>;
+
+  using hub_type = detail::worker_hub<worker_type>;
 
   /// Represents either an error or a serialized payload.
   using maybe_buffer = expected<std::vector<byte>>;
@@ -109,7 +111,7 @@ protected:
   /// Stores a proxy for interacting with the actor clock.
   actor timeout_proxy_;
 
-  detail::worker_hub<serializing_worker> hub_;
+  hub_type hub_;
 };
 
 using endpoint_manager_ptr = intrusive_ptr<endpoint_manager>;

--- a/libcaf_net/caf/net/endpoint_manager.hpp
+++ b/libcaf_net/caf/net/endpoint_manager.hpp
@@ -61,7 +61,7 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   endpoint_manager(socket handle, const multiplexer_ptr& parent,
-                   actor_system& sys);
+                   actor_system& sys, hub_type& hub);
 
   ~endpoint_manager() override = default;
 
@@ -107,7 +107,7 @@ protected:
   /// Stores a proxy for interacting with the actor clock.
   actor timeout_proxy_;
 
-  hub_type hub_;
+  hub_type& hub_;
 
   outgoing_message_queue message_queue_;
 };

--- a/libcaf_net/caf/net/endpoint_manager.hpp
+++ b/libcaf_net/caf/net/endpoint_manager.hpp
@@ -51,12 +51,9 @@ public:
 
   using hub_type = detail::worker_hub<serializing_worker>;
 
-  /// Represents either an error or a serialized payload.
-  using maybe_buffer = expected<std::vector<byte>>;
-
   /// A function type for serializing message payloads.
-  using serialize_fun_type = maybe_buffer (*)(actor_system&,
-                                              const type_erased_tuple&);
+  using serialize_fun_type = error (*)(actor_system&, const type_erased_tuple&,
+                                       std::vector<byte>&);
 
   // -- constructors, destructors, and assignment operators --------------------
 
@@ -97,6 +94,8 @@ public:
   /// @returns the protocol-specific function for serializing payloads.
   virtual serialize_fun_type serialize_fun() const noexcept = 0;
 
+  virtual std::vector<byte> next_payload_buffer() = 0;
+
 protected:
   /// Points to the hosting actor system.
   actor_system& sys_;
@@ -107,8 +106,10 @@ protected:
   /// Stores a proxy for interacting with the actor clock.
   actor timeout_proxy_;
 
+  /// Points to the serializing_worker hub.
   hub_type& hub_;
 
+  /// The message_queue that orders serialized messages.
   outgoing_message_queue message_queue_;
 };
 

--- a/libcaf_net/caf/net/endpoint_manager.hpp
+++ b/libcaf_net/caf/net/endpoint_manager.hpp
@@ -62,7 +62,7 @@ public:
   endpoint_manager(socket handle, const multiplexer_ptr& parent,
                    actor_system& sys);
 
-  ~endpoint_manager() override;
+  ~endpoint_manager() override = default;
 
   // -- properties -------------------------------------------------------------
 
@@ -74,12 +74,14 @@ public:
 
   // -- event management -------------------------------------------------------
 
+  void enqueue(mailbox_element_ptr elem, strong_actor_ptr receiver,
+               std::vector<byte> payload);
+
   /// Resolves a path to a remote actor.
-  void resolve(uri locator, actor listener);
+  void resolve(uri locator, const actor& listener);
 
   /// Enqueues a message to the endpoint.
-  void enqueue(mailbox_element_ptr msg, strong_actor_ptr receiver,
-               std::vector<byte> payload);
+  void enqueue(mailbox_element_ptr msg, actor_control_block* receiver);
 
   /// Enqueues an event to the endpoint.
   template <class... Ts>

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -24,6 +24,7 @@
 #include "caf/atom.hpp"
 #include "caf/detail/overload.hpp"
 #include "caf/net/endpoint_manager.hpp"
+#include "defaults.hpp"
 
 namespace caf::net {
 
@@ -75,8 +76,8 @@ public:
   // -- interface functions ----------------------------------------------------
 
   error init() override {
-    auto workers = get_or(system().config(), "middleman.workers",
-                          defaults::middleman::workers);
+    auto workers = get_or(system().config(), "middleman.serializing_workers",
+                          defaults::middleman::serializing_workers);
     for (size_t i = 0; i < workers; ++i)
       hub_.add_new_worker(system(), serialize_fun());
     this->register_reading();

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -44,8 +44,8 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   endpoint_manager_impl(const multiplexer_ptr& parent, actor_system& sys,
-                        Transport trans)
-    : super(trans.handle(), parent, sys), transport_(std::move(trans)) {
+                        Transport trans, hub_type& hub)
+    : super(trans.handle(), parent, sys, hub), transport_(std::move(trans)) {
     // nop
   }
 
@@ -79,11 +79,6 @@ public:
 
   error init() override {
     this->message_queue_.init(this);
-    auto workers = get_or(system().config(), "middleman.serializing_workers",
-                          defaults::middleman::serializing_workers);
-    CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for serializing");
-    for (size_t i = 0; i < workers; ++i)
-      hub_.add_new_worker(system(), this->message_queue_, serialize_fun());
     this->register_reading();
     return transport_.init(*this);
   }

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -128,6 +128,10 @@ public:
     return application_type::serialize;
   }
 
+  std::vector<byte> next_payload_buffer() {
+    return transport().next_payload_buffer();
+  }
+
 private:
   transport_type transport_;
 

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -78,7 +78,7 @@ public:
     auto workers = get_or(system()->config(), "middleman.workers",
                           defaults::middleman::workers);
     for (size_t i = 0; i < workers; ++i)
-      hub_.add_new_worker(hub_, system());
+      hub_.add_new_worker(hub_, system(), serialize_fun());
     this->register_reading();
     return transport_.init(*this);
   }

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -75,6 +75,10 @@ public:
   // -- interface functions ----------------------------------------------------
 
   error init() override {
+    auto workers = get_or(system()->config(), "middleman.workers",
+                          defaults::middleman::workers);
+    for (size_t i = 0; i < workers; ++i)
+      hub_.add_new_worker(hub_, system());
     this->register_reading();
     return transport_.init(*this);
   }

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -21,10 +21,12 @@
 #include "caf/abstract_actor.hpp"
 #include "caf/actor_cast.hpp"
 #include "caf/actor_system.hpp"
+#include "caf/actor_system_config.hpp"
 #include "caf/atom.hpp"
+#include "caf/defaults.hpp"
 #include "caf/detail/overload.hpp"
+#include "caf/net/defaults.hpp"
 #include "caf/net/endpoint_manager.hpp"
-#include "defaults.hpp"
 
 namespace caf::net {
 

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -75,10 +75,10 @@ public:
   // -- interface functions ----------------------------------------------------
 
   error init() override {
-    auto workers = get_or(system()->config(), "middleman.workers",
+    auto workers = get_or(system().config(), "middleman.workers",
                           defaults::middleman::workers);
     for (size_t i = 0; i < workers; ++i)
-      hub_.add_new_worker(hub_, system(), serialize_fun());
+      hub_.add_new_worker(system(), serialize_fun());
     this->register_reading();
     return transport_.init(*this);
   }

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -78,11 +78,12 @@ public:
   // -- interface functions ----------------------------------------------------
 
   error init() override {
+    this->message_queue_.init(this);
     auto workers = get_or(system().config(), "middleman.serializing_workers",
                           defaults::middleman::serializing_workers);
     CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for serializing");
     for (size_t i = 0; i < workers; ++i)
-      hub_.add_new_worker(system(), serialize_fun());
+      hub_.add_new_worker(system(), this->message_queue_, serialize_fun());
     this->register_reading();
     return transport_.init(*this);
   }

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -78,6 +78,7 @@ public:
   error init() override {
     auto workers = get_or(system().config(), "middleman.serializing_workers",
                           defaults::middleman::serializing_workers);
+    CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for serializing");
     for (size_t i = 0; i < workers; ++i)
       hub_.add_new_worker(system(), serialize_fun());
     this->register_reading();

--- a/libcaf_net/caf/net/endpoint_manager_queue.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_queue.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "caf/actor.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"
 #include "caf/intrusive/drr_queue.hpp"
 #include "caf/intrusive/fifo_inbox.hpp"
@@ -54,7 +55,7 @@ public:
 
   using element_ptr = std::unique_ptr<element>;
 
-  class event final : public element {
+  class CAF_NET_EXPORT event final : public element {
   public:
     struct resolve_request {
       uri locator;

--- a/libcaf_net/caf/net/make_endpoint_manager.hpp
+++ b/libcaf_net/caf/net/make_endpoint_manager.hpp
@@ -19,20 +19,19 @@
 #pragma once
 
 #include "caf/detail/net_export.hpp"
-#include "caf/detail/worker_hub.hpp"
 #include "caf/make_counted.hpp"
 #include "caf/net/endpoint_manager.hpp"
 #include "caf/net/endpoint_manager_impl.hpp"
-#include "caf/net/serializing_worker.hpp"
+#include "caf/net/multiplexer.hpp"
 
 namespace caf::net {
 
 template <class Transport>
 endpoint_manager_ptr CAF_NET_EXPORT make_endpoint_manager(
-  const multiplexer_ptr& mpx, actor_system& sys, Transport trans,
-  detail::worker_hub<serializing_worker>& hub) {
+  const multiplexer_ptr& mpx, actor_system& sys, Transport trans) {
   using impl = endpoint_manager_impl<Transport>;
-  return make_counted<impl>(mpx, sys, std::move(trans), hub);
+  return make_counted<impl>(mpx, sys, std::move(trans),
+                            mpx->serializing_worker_hub());
 }
 
 } // namespace caf::net

--- a/libcaf_net/caf/net/make_endpoint_manager.hpp
+++ b/libcaf_net/caf/net/make_endpoint_manager.hpp
@@ -19,17 +19,20 @@
 #pragma once
 
 #include "caf/detail/net_export.hpp"
+#include "caf/detail/worker_hub.hpp"
 #include "caf/make_counted.hpp"
 #include "caf/net/endpoint_manager.hpp"
 #include "caf/net/endpoint_manager_impl.hpp"
+#include "caf/net/serializing_worker.hpp"
 
 namespace caf::net {
 
 template <class Transport>
 endpoint_manager_ptr CAF_NET_EXPORT make_endpoint_manager(
-  const multiplexer_ptr& mpx, actor_system& sys, Transport trans) {
+  const multiplexer_ptr& mpx, actor_system& sys, Transport trans,
+  detail::worker_hub<serializing_worker>& hub) {
   using impl = endpoint_manager_impl<Transport>;
-  return make_counted<impl>(mpx, sys, std::move(trans));
+  return make_counted<impl>(mpx, sys, std::move(trans), hub);
 }
 
 } // namespace caf::net

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <thread>
 
+#include "caf/detail/net_export.hpp"
 #include "caf/detail/worker_hub.hpp"
 #include "caf/net/basp/worker.hpp"
 #include "caf/net/fwd.hpp"
@@ -40,7 +41,8 @@ struct pollfd;
 namespace caf::net {
 
 /// Multiplexes any number of ::socket_manager objects with a ::socket.
-class multiplexer : public std::enable_shared_from_this<multiplexer> {
+class CAF_NET_EXPORT multiplexer
+  : public std::enable_shared_from_this<multiplexer> {
 public:
   // -- member types -----------------------------------------------------------
 

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -22,9 +22,12 @@
 #include <mutex>
 #include <thread>
 
+#include "caf/detail/worker_hub.hpp"
+#include "caf/net/basp/worker.hpp"
 #include "caf/net/fwd.hpp"
 #include "caf/net/operation.hpp"
 #include "caf/net/pipe_socket.hpp"
+#include "caf/net/serializing_worker.hpp"
 #include "caf/net/socket.hpp"
 #include "caf/ref_counted.hpp"
 
@@ -45,9 +48,11 @@ public:
 
   using manager_list = std::vector<socket_manager_ptr>;
 
+  using serializing_worker_hub_type = detail::worker_hub<serializing_worker>;
+
   // -- constructors, destructors, and assignment operators --------------------
 
-  multiplexer();
+  multiplexer(actor_system& cfg);
 
   ~multiplexer();
 
@@ -60,6 +65,8 @@ public:
 
   /// Returns the index of `mgr` in the pollset or `-1`.
   ptrdiff_t index_of(const socket_manager_ptr& mgr);
+
+  serializing_worker_hub_type& serializing_worker_hub() noexcept;
 
   // -- thread-safe signaling --------------------------------------------------
 
@@ -110,6 +117,9 @@ protected:
 
   // -- member variables -------------------------------------------------------
 
+  ///
+  actor_system& sys_;
+
   /// Bookkeeping data for managed sockets.
   pollfd_list pollset_;
 
@@ -129,6 +139,9 @@ protected:
 
   /// Signals shutdown has been requested.
   bool shutting_down_;
+
+  /// Global serializing worker hub.
+  serializing_worker_hub_type serializing_worker_hub_;
 };
 
 /// @relates multiplexer

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -52,11 +52,11 @@ public:
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  multiplexer(actor_system& cfg);
+  multiplexer();
 
   ~multiplexer();
 
-  error init();
+  error init(actor_system& sys);
 
   // -- properties -------------------------------------------------------------
 
@@ -116,9 +116,6 @@ protected:
   void write_to_pipe(uint8_t opcode, const socket_manager_ptr& mgr);
 
   // -- member variables -------------------------------------------------------
-
-  ///
-  actor_system& sys_;
 
   /// Bookkeeping data for managed sockets.
   pollfd_list pollset_;

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -50,6 +50,8 @@ public:
 
   using serializing_worker_hub_type = detail::worker_hub<serializing_worker>;
 
+  using basp_worker_hub_type = detail::worker_hub<basp::worker>;
+
   // -- constructors, destructors, and assignment operators --------------------
 
   multiplexer();
@@ -66,7 +68,11 @@ public:
   /// Returns the index of `mgr` in the pollset or `-1`.
   ptrdiff_t index_of(const socket_manager_ptr& mgr);
 
+  /// Returns a reference to the `serializing_worker_hub`.
   serializing_worker_hub_type& serializing_worker_hub() noexcept;
+
+  /// Returns a reference to the `basp_worker_hub`.
+  basp_worker_hub_type& basp_worker_hub() noexcept;
 
   // -- thread-safe signaling --------------------------------------------------
 
@@ -139,6 +145,9 @@ protected:
 
   /// Global serializing worker hub.
   serializing_worker_hub_type serializing_worker_hub_;
+
+  /// Global basp worker hub.
+  basp_worker_hub_type basp_worker_hub_;
 };
 
 /// @relates multiplexer

--- a/libcaf_net/caf/net/outgoing_message_handler.hpp
+++ b/libcaf_net/caf/net/outgoing_message_handler.hpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <vector>
+
+#include "caf/actor_control_block.hpp"
+#include "caf/actor_proxy.hpp"
+#include "caf/binary_deserializer.hpp"
+#include "caf/config.hpp"
+#include "caf/detail/scope_guard.hpp"
+#include "caf/detail/sync_request_bouncer.hpp"
+#include "caf/execution_unit.hpp"
+#include "caf/logger.hpp"
+#include "caf/message.hpp"
+#include "caf/message_id.hpp"
+#include "caf/net/basp/header.hpp"
+#include "caf/node_id.hpp"
+
+namespace caf::net {
+
+// TODO: Find better name for this. The whole thing is cloning the
+// remote_message_handler design - Maybe find a better name for that too?
+template <class Subtype>
+class outgoing_message_handler {
+public:
+  void handle_outgoing_message(execution_unit*) {
+    using message_type = endpoint_manager_queue::message;
+    auto& elem = this->mailbox_elem_;
+    auto content = this->mailbox_elem_->content();
+    if (auto payload = sf_(system, content))
+      this->manager_.enqueue(new message_type(std::move(elem),
+                                              std::move(receiver),
+                                              std::move(payload)));
+    else
+      CAF_LOG_ERROR("unable to serialize payload: "
+                    << this->system().render(payload.error()));
+  }
+};
+
+} // namespace caf::net

--- a/libcaf_net/caf/net/outgoing_message_handler.hpp
+++ b/libcaf_net/caf/net/outgoing_message_handler.hpp
@@ -30,10 +30,10 @@ public:
     auto& content = dref.mailbox_elem_->content();
     if (auto payload = dref.sf_(*dref.system_, content))
       dref.manager_->enqueue(std::move(dref.mailbox_elem_),
-                             std::move(dref.receiver_), std::move(payload));
+                             std::move(dref.receiver_), std::move(*payload));
     else
       CAF_LOG_ERROR("unable to serialize payload: "
-                    << dref.system_.render(payload.error()));
+                    << dref.system_->render(payload.error()));
   }
 };
 

--- a/libcaf_net/caf/net/outgoing_message_queue.hpp
+++ b/libcaf_net/caf/net/outgoing_message_queue.hpp
@@ -1,0 +1,85 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include "caf/actor_control_block.hpp"
+#include "caf/fwd.hpp"
+#include "caf/mailbox_element.hpp"
+#include "caf/net/endpoint_manager_queue.hpp"
+#include "caf/net/fwd.hpp"
+
+namespace caf::net {
+
+/// Enforces strict order of message delivery to a single endpoint_manager
+/// i.e., deliver messages in the same order as if they were deserialized by a
+/// single thread.
+class outgoing_message_queue {
+public:
+  // -- member types -----------------------------------------------------------
+
+  /// Request for sending a message to an actor at a later time.
+  struct serialized_message {
+    uint64_t id;
+    endpoint_manager_queue::element* content;
+  };
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  explicit outgoing_message_queue();
+
+  // -- mutators ---------------------------------------------------------------
+
+  void init(endpoint_manager* manager);
+
+  /// Adds a new message to the queue or deliver it immediately if possible.
+  void push(uint64_t id, endpoint_manager_queue::element* ptr);
+
+  /// Marks given ID as dropped, effectively skipping it without effect.
+  void drop(uint64_t id);
+
+  /// Returns the next ascending ID.
+  uint64_t new_id();
+
+private:
+  // -- member variables -------------------------------------------------------
+
+  /// Protects all other properties.
+  std::mutex lock;
+
+  /// The next available ascending ID. The counter is large enough to overflow
+  /// after roughly 600 years if we dispatch a message every microsecond.
+  uint64_t next_id;
+
+  /// The next ID that we can ship.
+  uint64_t next_undelivered;
+
+  /// Keeps messages in sorted order in case a message other than
+  /// `next_undelivered` gets ready first.
+  std::vector<serialized_message> pending;
+
+  /// The `endpoint_manager` the ordered serialized messages should be
+  /// delivered to.
+  endpoint_manager* manager_;
+};
+
+} // namespace caf::net

--- a/libcaf_net/caf/net/outgoing_message_queue.hpp
+++ b/libcaf_net/caf/net/outgoing_message_queue.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "caf/actor_control_block.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"
 #include "caf/mailbox_element.hpp"
 #include "caf/net/endpoint_manager_queue.hpp"
@@ -33,7 +34,7 @@ namespace caf::net {
 /// Enforces strict order of message delivery to a single endpoint_manager
 /// i.e., deliver messages in the same order as if they were deserialized by a
 /// single thread.
-class outgoing_message_queue {
+class CAF_NET_EXPORT outgoing_message_queue {
 public:
   // -- member types -----------------------------------------------------------
 

--- a/libcaf_net/caf/net/serializing_worker.hpp
+++ b/libcaf_net/caf/net/serializing_worker.hpp
@@ -1,0 +1,97 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+#include "caf/config.hpp"
+#include "caf/detail/abstract_worker.hpp"
+#include "caf/detail/worker_hub.hpp"
+#include "caf/net/basp/header.hpp"
+#include "caf/net/basp/message_queue.hpp"
+#include "caf/net/basp/remote_message_handler.hpp"
+#include "caf/net/fwd.hpp"
+#include "caf/net/outgoing_message_handler.hpp"
+#include "caf/node_id.hpp"
+#include "caf/resumable.hpp"
+
+namespace caf::net {
+
+/// Asynchronously serializes outgoing messages.
+class serializing_worker : public detail::abstract_worker,
+                           public outgoing_message_handler<serializing_worker> {
+public:
+  // -- member types -----------------------------------------------------------
+
+  using super = detail::abstract_worker;
+
+  using scheduler_type = scheduler::abstract_coordinator;
+
+  using buffer_type = std::vector<byte>;
+
+  using hub_type = detail::worker_hub<serializing_worker>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  /// Only the ::worker_hub has access to the construtor.
+  serializing_worker(hub_type& hub, actor_system& sys);
+
+  ~serializing_worker() override = default;
+
+  // -- management -------------------------------------------------------------
+
+  void launch(mailbox_element_ptr mailbox_elem, actor_control_block* ctrl,
+              endpoint_manager* manager);
+
+  // -- implementation of resumable --------------------------------------------
+
+  resume_result resume(execution_unit* ctx, size_t) override;
+
+private:
+  // -- constants and assertions -----------------------------------------------
+
+  /// Stores how many bytes the "first half" of this object requires.
+  static constexpr size_t pointer_members_size = sizeof(hub_type*)
+                                                 + sizeof(proxy_registry*)
+                                                 + sizeof(actor_system*);
+
+  static_assert(CAF_CACHE_LINE_SIZE > pointer_members_size,
+                "invalid cache line size");
+
+  // -- member variables -------------------------------------------------------
+
+  /// Points to our home hub.
+  hub_type* hub_;
+
+  /// Points to the parent system.
+  actor_system* system_;
+
+  /// The `mailbox_element` that should be serialized.
+  mailbox_element_ptr mailbox_elem_;
+
+  /// Points to the `actor_control_block` of the receiver.
+  actor_control_block* ctrl_;
+
+  /// Points to the endpoint_manager that should receive the serialized message.
+  endpoint_manager* manager_;
+};
+
+} // namespace caf::net

--- a/libcaf_net/caf/net/serializing_worker.hpp
+++ b/libcaf_net/caf/net/serializing_worker.hpp
@@ -68,14 +68,14 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   /// Only the ::worker_hub has access to the construtor.
-  serializing_worker(hub_type& hub, actor_system& sys,
-                     outgoing_message_queue& queue, serialize_fun_type sf);
+  serializing_worker(hub_type& hub, actor_system& sys);
 
   ~serializing_worker() override = default;
 
   // -- management -------------------------------------------------------------
 
-  void launch(mailbox_element_ptr mailbox_elem, strong_actor_ptr ctrl);
+  void launch(mailbox_element_ptr mailbox_elem, strong_actor_ptr ctrl,
+              outgoing_message_queue& queue, serialize_fun_type sf);
 
   // -- implementation of resumable --------------------------------------------
 

--- a/libcaf_net/caf/net/socket_manager.hpp
+++ b/libcaf_net/caf/net/socket_manager.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "caf/detail/net_export.hpp"
 #include "caf/error.hpp"
 #include "caf/fwd.hpp"
 #include "caf/net/fwd.hpp"
@@ -28,7 +29,7 @@
 namespace caf::net {
 
 /// Manages the lifetime of a single socket and handles any I/O events on it.
-class socket_manager : public ref_counted {
+class CAF_NET_EXPORT socket_manager : public ref_counted {
 public:
   // -- constructors, destructors, and assignment operators --------------------
 

--- a/libcaf_net/caf/net/stream_transport.hpp
+++ b/libcaf_net/caf/net/stream_transport.hpp
@@ -180,6 +180,7 @@ private:
         if (this->header_bufs_.size() < this->header_bufs_.capacity())
           this->header_bufs_.emplace_back(std::move(buf));
       } else if (this->payload_bufs_.size() < this->payload_bufs_.capacity()) {
+        const std::lock_guard<std::mutex> lock(*this->payload_buffer_lock_);
         this->payload_bufs_.emplace_back(std::move(buf));
       }
       write_queue_.pop_front();

--- a/libcaf_net/caf/net/transport_base.hpp
+++ b/libcaf_net/caf/net/transport_base.hpp
@@ -58,7 +58,10 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   transport_base(handle_type handle, application_type application)
-    : next_layer_(std::move(application)), handle_(handle), manager_(nullptr) {
+    : payload_buffer_lock_{std::make_shared<std::mutex>()},
+      next_layer_(std::move(application)),
+      handle_(handle),
+      manager_(nullptr) {
     // nop
   }
 
@@ -204,6 +207,7 @@ public:
   /// Returns the next cached payload buffer or creates a new one if no buffers
   /// are cached.
   buffer_type next_payload_buffer() {
+    const std::lock_guard<std::mutex> lock(*payload_buffer_lock_);
     return next_buffer_impl(payload_bufs_);
   }
 
@@ -219,6 +223,9 @@ private:
   }
 
 protected:
+  /// Lock for synchronizing payload_buffer_cache access.
+  std::shared_ptr<std::mutex> payload_buffer_lock_;
+
   /// Next Layer of this stack.
   next_layer_type next_layer_;
 

--- a/libcaf_net/caf/net/transport_base.hpp
+++ b/libcaf_net/caf/net/transport_base.hpp
@@ -219,14 +219,22 @@ private:
   }
 
 protected:
+  /// Next Layer of this stack.
   next_layer_type next_layer_;
+
+  /// The socket handle of this transport.
   handle_type handle_;
 
+  /// Buffer cache containing header buffers.
   buffer_cache_type header_bufs_;
+
+  /// Buffer cache containing payload buffers.
   buffer_cache_type payload_bufs_;
 
+  /// Read buffer of this transport.
   buffer_type read_buf_;
 
+  /// Points to the endpoint_manager of this transport.
   endpoint_manager* manager_;
 
   size_t max_consecutive_reads_;

--- a/libcaf_net/src/actor_proxy_impl.cpp
+++ b/libcaf_net/src/actor_proxy_impl.cpp
@@ -38,11 +38,7 @@ void actor_proxy_impl::enqueue(mailbox_element_ptr what, execution_unit*) {
   CAF_PUSH_AID(0);
   CAF_ASSERT(what != nullptr);
   CAF_LOG_SEND_EVENT(what);
-  if (auto payload = sf_(home_system(), what->content()))
-    dst_->enqueue(std::move(what), ctrl(), std::move(*payload));
-  else
-    CAF_LOG_ERROR(
-      "unable to serialize payload: " << home_system().render(payload.error()));
+  dst_->enqueue(std::move(what), ctrl(), {});
 }
 
 void actor_proxy_impl::kill_proxy(execution_unit* ctx, error rsn) {

--- a/libcaf_net/src/actor_proxy_impl.cpp
+++ b/libcaf_net/src/actor_proxy_impl.cpp
@@ -30,15 +30,11 @@ actor_proxy_impl::actor_proxy_impl(actor_config& cfg, endpoint_manager_ptr dst)
   dst_->enqueue_event(node(), id());
 }
 
-actor_proxy_impl::~actor_proxy_impl() {
-  // nop
-}
-
 void actor_proxy_impl::enqueue(mailbox_element_ptr what, execution_unit*) {
   CAF_PUSH_AID(0);
   CAF_ASSERT(what != nullptr);
   CAF_LOG_SEND_EVENT(what);
-  dst_->enqueue(std::move(what), ctrl(), {});
+  dst_->enqueue(std::move(what), ctrl());
 }
 
 void actor_proxy_impl::kill_proxy(execution_unit* ctx, error rsn) {

--- a/libcaf_net/src/application.cpp
+++ b/libcaf_net/src/application.cpp
@@ -29,7 +29,6 @@
 #include "caf/detail/network_order.hpp"
 #include "caf/detail/parse.hpp"
 #include "caf/error.hpp"
-#include "caf/expected.hpp"
 #include "caf/logger.hpp"
 #include "caf/net/basp/constants.hpp"
 #include "caf/net/basp/ec.hpp"
@@ -119,13 +118,12 @@ void application::local_actor_down(packet_writer& writer, actor_id id,
   writer.write_packet(hdr, payload);
 }
 
-expected<std::vector<byte>> application::serialize(actor_system& sys,
-                                                   const type_erased_tuple& x) {
-  std::vector<byte> result;
-  binary_serializer sink{sys, result};
+error application::serialize(actor_system& sys, const type_erased_tuple& x,
+                             std::vector<byte>& buf) {
+  binary_serializer sink{sys, buf};
   if (auto err = message::save(sink, x))
     return err.value();
-  return result;
+  return none;
 }
 
 strong_actor_ptr application::resolve_local_path(string_view path) {

--- a/libcaf_net/src/defaults.cpp
+++ b/libcaf_net/src/defaults.cpp
@@ -18,6 +18,7 @@
 
 #include "caf/net/defaults.hpp"
 
+#include <algorithm>
 #include <thread>
 
 using std::min;

--- a/libcaf_net/src/defaults.cpp
+++ b/libcaf_net/src/defaults.cpp
@@ -18,7 +18,15 @@
 
 #include "caf/net/defaults.hpp"
 
+#include <thread>
+
+using std::min;
+using std::thread;
+
 namespace caf::defaults::middleman {
+
+const size_t serializing_workers = min(3u, thread::hardware_concurrency() / 4u)
+                                   + 1;
 
 const size_t max_payload_buffers = 100;
 

--- a/libcaf_net/src/defaults.cpp
+++ b/libcaf_net/src/defaults.cpp
@@ -18,16 +18,9 @@
 
 #include "caf/net/defaults.hpp"
 
-#include <algorithm>
-#include <thread>
-
-using std::min;
-using std::thread;
-
 namespace caf::defaults::middleman {
 
-const size_t serializing_workers = min(3u, thread::hardware_concurrency() / 4u)
-                                   + 1;
+const size_t serializing_workers = 0;
 
 const size_t max_payload_buffers = 100;
 

--- a/libcaf_net/src/endpoint_manager.cpp
+++ b/libcaf_net/src/endpoint_manager.cpp
@@ -68,7 +68,7 @@ void endpoint_manager::enqueue(mailbox_element_ptr msg,
       "out of serializing workers, continue deserializing an actor_message");
     // If no worker is available then we have no other choice than to take
     // the performance hit and serialize in this thread.
-    struct handler : public outgoing_message_handler<serializing_worker> {
+    struct handler : public outgoing_message_handler<worker_type> {
       handler(hub_type& hub, actor_system& sys,
               mailbox_element_ptr mailbox_elem, actor_control_block* ctrl,
               endpoint_manager* manager,

--- a/libcaf_net/src/endpoint_manager.cpp
+++ b/libcaf_net/src/endpoint_manager.cpp
@@ -60,12 +60,11 @@ void endpoint_manager::enqueue(mailbox_element_ptr msg,
                                actor_control_block* receiver) {
   auto worker = hub_.pop();
   if (worker != nullptr) {
-    CAF_LOG_DEBUG(
-      "launch serializing worker for deserializing an actor_message");
+    CAF_LOG_DEBUG("launch serializing worker for serializing an actor_message");
     worker->launch(std::move(msg), receiver->get()->ctrl(), this);
   } else {
     CAF_LOG_DEBUG(
-      "out of serializing workers, continue deserializing an actor_message");
+      "out of serializing workers, continue serializing an actor_message");
     // If no worker is available then we have no other choice than to take
     // the performance hit and serialize in this thread.
     struct handler : public outgoing_message_handler<handler> {

--- a/libcaf_net/src/endpoint_manager.cpp
+++ b/libcaf_net/src/endpoint_manager.cpp
@@ -68,15 +68,15 @@ void endpoint_manager::enqueue(mailbox_element_ptr msg,
       "out of serializing workers, continue deserializing an actor_message");
     // If no worker is available then we have no other choice than to take
     // the performance hit and serialize in this thread.
-    struct handler : public outgoing_message_handler<worker_type> {
+    struct handler : public outgoing_message_handler<handler> {
       handler(hub_type& hub, actor_system& sys,
-              mailbox_element_ptr mailbox_elem, actor_control_block* ctrl,
+              mailbox_element_ptr mailbox_elem, strong_actor_ptr receiver,
               endpoint_manager* manager,
               endpoint_manager::serialize_fun_type sf)
         : hub_(&hub),
           system_(&sys),
           mailbox_elem_(std::move(mailbox_elem)),
-          ctrl_(ctrl),
+          receiver_(std::move(receiver)),
           manager_(manager),
           sf_(sf) {
         // nop
@@ -84,9 +84,9 @@ void endpoint_manager::enqueue(mailbox_element_ptr msg,
       hub_type* hub_;
       actor_system* system_;
       mailbox_element_ptr mailbox_elem_;
-      actor_control_block* ctrl_;
+      strong_actor_ptr receiver_;
       endpoint_manager* manager_;
-      endpoint_manager::serialize_fun_type sf_;
+      serialize_fun_type sf_;
     };
     handler f{hub_, system(),       std::move(msg), receiver->get()->ctrl(),
               this, serialize_fun()};

--- a/libcaf_net/src/endpoint_manager.cpp
+++ b/libcaf_net/src/endpoint_manager.cpp
@@ -27,8 +27,8 @@
 namespace caf::net {
 
 endpoint_manager::endpoint_manager(socket handle, const multiplexer_ptr& parent,
-                                   actor_system& sys)
-  : super(handle, parent), sys_(sys), queue_(unit, unit, unit) {
+                                   actor_system& sys, hub_type& hub)
+  : super(handle, parent), sys_(sys), queue_(unit, unit, unit), hub_(hub) {
   queue_.try_block();
 }
 
@@ -61,7 +61,8 @@ void endpoint_manager::enqueue(mailbox_element_ptr msg,
   auto worker = hub_.pop();
   if (worker != nullptr) {
     CAF_LOG_DEBUG("launch serializing worker for serializing an actor_message");
-    worker->launch(std::move(msg), receiver->get()->ctrl());
+    worker->launch(std::move(msg), receiver->get()->ctrl(), message_queue_,
+                   serialize_fun());
   } else {
     CAF_LOG_DEBUG(
       "out of serializing workers, continue serializing an actor_message");

--- a/libcaf_net/src/multiplexer.cpp
+++ b/libcaf_net/src/multiplexer.cpp
@@ -78,7 +78,7 @@ short to_bitmask(operation op) {
 
 } // namespace
 
-multiplexer::multiplexer(actor_system& sys) : sys_(sys), shutting_down_(false) {
+multiplexer::multiplexer() : shutting_down_(false) {
   // nop
 }
 
@@ -86,17 +86,17 @@ multiplexer::~multiplexer() {
   // nop
 }
 
-error multiplexer::init() {
+error multiplexer::init(actor_system& sys) {
   auto pipe_handles = make_pipe();
   if (!pipe_handles)
     return std::move(pipe_handles.error());
   add(make_counted<pollset_updater>(pipe_handles->first, shared_from_this()));
   write_handle_ = pipe_handles->second;
-  auto workers = get_or(sys_.config(), "middleman.serializing_workers",
+  auto workers = get_or(sys.config(), "middleman.serializing_workers",
                         defaults::middleman::serializing_workers);
   CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for serializing");
   for (size_t i = 0; i < workers; ++i)
-    serializing_worker_hub_.add_new_worker(sys_);
+    serializing_worker_hub_.add_new_worker(sys);
   return none;
 }
 

--- a/libcaf_net/src/multiplexer.cpp
+++ b/libcaf_net/src/multiplexer.cpp
@@ -23,6 +23,7 @@
 #include "caf/actor_system_config.hpp"
 #include "caf/byte.hpp"
 #include "caf/config.hpp"
+#include "caf/defaults.hpp"
 #include "caf/error.hpp"
 #include "caf/expected.hpp"
 #include "caf/logger.hpp"
@@ -97,6 +98,11 @@ error multiplexer::init(actor_system& sys) {
   CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for serializing");
   for (size_t i = 0; i < workers; ++i)
     serializing_worker_hub_.add_new_worker(sys);
+  workers = get_or(sys.config(), "middleman.workers",
+                   defaults::middleman::workers);
+  CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for deserializing");
+  for (size_t i = 0; i < workers; ++i)
+    basp_worker_hub_.add_new_worker(sys);
   return none;
 }
 
@@ -114,6 +120,10 @@ ptrdiff_t multiplexer::index_of(const socket_manager_ptr& mgr) {
 multiplexer::serializing_worker_hub_type&
 multiplexer::serializing_worker_hub() noexcept {
   return serializing_worker_hub_;
+}
+
+multiplexer::basp_worker_hub_type& multiplexer::basp_worker_hub() noexcept {
+  return basp_worker_hub_;
 }
 
 void multiplexer::register_reading(const socket_manager_ptr& mgr) {

--- a/libcaf_net/src/net/backend/test.cpp
+++ b/libcaf_net/src/net/backend/test.cpp
@@ -79,7 +79,7 @@ test::peer_entry& test::emplace(const node_id& peer_id, stream_socket first,
   using transport_type = stream_transport<basp::application>;
   nonblocking(second, true);
   auto mpx = mm_.mpx();
-  basp::application app{proxies_};
+  basp::application app{proxies_, mpx->basp_worker_hub()};
   auto mgr = make_endpoint_manager(mpx, mm_.system(),
                                    transport_type{second, std::move(app)});
   if (auto err = mgr->init()) {

--- a/libcaf_net/src/net/backend/test.cpp
+++ b/libcaf_net/src/net/backend/test.cpp
@@ -41,11 +41,6 @@ test::~test() {
 }
 
 error test::init() {
-  auto workers = get_or(mm_.system().config(), "middleman.serializing_workers",
-                        defaults::middleman::serializing_workers);
-  CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for serializing");
-  for (size_t i = 0; i < workers; ++i)
-    hub_.add_new_worker(mm_.system());
   return none;
 }
 
@@ -86,8 +81,7 @@ test::peer_entry& test::emplace(const node_id& peer_id, stream_socket first,
   auto mpx = mm_.mpx();
   basp::application app{proxies_};
   auto mgr = make_endpoint_manager(mpx, mm_.system(),
-                                   transport_type{second, std::move(app)},
-                                   hub_);
+                                   transport_type{second, std::move(app)});
   if (auto err = mgr->init()) {
     CAF_LOG_ERROR("mgr->init() failed: " << mm_.system().render(err));
     CAF_RAISE_ERROR("mgr->init() failed");

--- a/libcaf_net/src/net/backend/test.cpp
+++ b/libcaf_net/src/net/backend/test.cpp
@@ -41,6 +41,11 @@ test::~test() {
 }
 
 error test::init() {
+  auto workers = get_or(mm_.system().config(), "middleman.serializing_workers",
+                        defaults::middleman::serializing_workers);
+  CAF_LOG_DEBUG("using " << CAF_ARG(workers) << " for serializing");
+  for (size_t i = 0; i < workers; ++i)
+    hub_.add_new_worker(mm_.system());
   return none;
 }
 
@@ -81,7 +86,8 @@ test::peer_entry& test::emplace(const node_id& peer_id, stream_socket first,
   auto mpx = mm_.mpx();
   basp::application app{proxies_};
   auto mgr = make_endpoint_manager(mpx, mm_.system(),
-                                   transport_type{second, std::move(app)});
+                                   transport_type{second, std::move(app)},
+                                   hub_);
   if (auto err = mgr->init()) {
     CAF_LOG_ERROR("mgr->init() failed: " << mm_.system().render(err));
     CAF_RAISE_ERROR("mgr->init() failed");

--- a/libcaf_net/src/net/middleman.cpp
+++ b/libcaf_net/src/net/middleman.cpp
@@ -30,7 +30,7 @@
 namespace caf::net {
 
 middleman::middleman(actor_system& sys) : sys_(sys) {
-  mpx_ = std::make_shared<multiplexer>(sys_);
+  mpx_ = std::make_shared<multiplexer>();
 }
 
 middleman::~middleman() {
@@ -63,7 +63,7 @@ void middleman::stop() {
 }
 
 void middleman::init(actor_system_config& cfg) {
-  if (auto err = mpx_->init()) {
+  if (auto err = mpx_->init(sys_)) {
     CAF_LOG_ERROR("mgr->init() failed: " << system().render(err));
     CAF_RAISE_ERROR("mpx->init() failed");
   }

--- a/libcaf_net/src/net/middleman.cpp
+++ b/libcaf_net/src/net/middleman.cpp
@@ -30,7 +30,7 @@
 namespace caf::net {
 
 middleman::middleman(actor_system& sys) : sys_(sys) {
-  mpx_ = std::make_shared<multiplexer>();
+  mpx_ = std::make_shared<multiplexer>(sys_);
 }
 
 middleman::~middleman() {

--- a/libcaf_net/src/outgoing_message_queue.cpp
+++ b/libcaf_net/src/outgoing_message_queue.cpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/net/outgoing_message_queue.hpp"
+
+#include <iterator>
+
+#include "caf/net/endpoint_manager.hpp"
+
+namespace caf::net {
+
+outgoing_message_queue::outgoing_message_queue()
+  : next_id(0), next_undelivered(0), manager_(nullptr) {
+  // nop
+}
+
+void outgoing_message_queue::init(caf::net::endpoint_manager* manager) {
+  manager_ = manager;
+}
+
+void outgoing_message_queue::push(uint64_t id,
+                                  endpoint_manager_queue::element* content) {
+  std::unique_lock<std::mutex> guard{lock};
+  CAF_ASSERT(id >= next_undelivered);
+  CAF_ASSERT(id < next_id);
+  auto first = pending.begin();
+  auto last = pending.end();
+  if (id == next_undelivered) {
+    // Dispatch current head.
+    manager_->enqueue(content);
+    auto next = id + 1;
+    // Check whether we can deliver more.
+    if (first == last || first->id != next) {
+      next_undelivered = next;
+      CAF_ASSERT(next_undelivered <= next_id);
+      return;
+    }
+    // Deliver everything until reaching a non-consecutive ID or the end.
+    auto i = first;
+    for (; i != last && i->id == next; ++i, ++next)
+      manager_->enqueue(i->content);
+    next_undelivered = next;
+    pending.erase(first, i);
+    CAF_ASSERT(next_undelivered <= next_id);
+    return;
+  }
+  // Get the insertion point.
+  auto pred = [&](const serialized_message& x) { return x.id >= id; };
+  pending.emplace(std::find_if(first, last, pred),
+                  serialized_message{id, content});
+}
+
+void outgoing_message_queue::drop(uint64_t id) {
+  push(id, nullptr);
+}
+
+uint64_t outgoing_message_queue::new_id() {
+  std::unique_lock<std::mutex> guard{lock};
+  return next_id++;
+}
+
+} // namespace caf::net

--- a/libcaf_net/src/serializing_worker.cpp
+++ b/libcaf_net/src/serializing_worker.cpp
@@ -27,7 +27,7 @@ namespace caf::net {
 // -- constructors, destructors, and assignment operators ----------------------
 
 serializing_worker::serializing_worker(hub_type& hub, actor_system& sys)
-  : msg_id_(0), hub_(&hub), system_(&sys) {
+  : msg_id_(0), hub_(&hub), system_(&sys), queue_(nullptr) {
   // nop
 }
 
@@ -36,12 +36,13 @@ serializing_worker::serializing_worker(hub_type& hub, actor_system& sys)
 void serializing_worker::launch(mailbox_element_ptr mailbox_elem,
                                 strong_actor_ptr ctrl,
                                 outgoing_message_queue& queue,
-                                serialize_fun_type sf) {
+                                serialize_fun_type sf, std::vector<byte> buf) {
   queue_ = &queue;
   msg_id_ = queue_->new_id();
   mailbox_elem_ = std::move(mailbox_elem);
   receiver_ = std::move(ctrl);
   sf_ = sf;
+  buf_ = std::move(buf);
   ref();
   system_->scheduler().enqueue(this);
 }

--- a/libcaf_net/src/serializing_worker.cpp
+++ b/libcaf_net/src/serializing_worker.cpp
@@ -28,18 +28,19 @@ namespace caf::net {
 
 // -- constructors, destructors, and assignment operators ----------------------
 
-serializing_worker::serializing_worker(hub_type& hub, actor_system& sys)
-  : hub_(&hub), system_(&sys), ctrl_(nullptr), manager_(nullptr) {
+serializing_worker::serializing_worker(hub_type& hub, actor_system& sys,
+                                       serialize_fun_type sf)
+  : hub_(&hub), system_(&sys), manager_(nullptr), sf_(sf) {
   // nop
 }
 
 // -- management ---------------------------------------------------------------
 
 void serializing_worker::launch(mailbox_element_ptr mailbox_elem,
-                                actor_control_block* ctrl,
+                                strong_actor_ptr ctrl,
                                 endpoint_manager* manager) {
   mailbox_elem_ = std::move(mailbox_elem);
-  ctrl_ = ctrl;
+  receiver_ = std::move(ctrl);
   manager_ = manager;
   ref();
   system_->scheduler().enqueue(this);

--- a/libcaf_net/src/serializing_worker.cpp
+++ b/libcaf_net/src/serializing_worker.cpp
@@ -26,20 +26,22 @@ namespace caf::net {
 
 // -- constructors, destructors, and assignment operators ----------------------
 
-serializing_worker::serializing_worker(hub_type& hub, actor_system& sys,
-                                       outgoing_message_queue& queue,
-                                       serialize_fun_type sf)
-  : msg_id_(0), hub_(&hub), system_(&sys), queue_(&queue), sf_(sf) {
+serializing_worker::serializing_worker(hub_type& hub, actor_system& sys)
+  : msg_id_(0), hub_(&hub), system_(&sys) {
   // nop
 }
 
 // -- management ---------------------------------------------------------------
 
 void serializing_worker::launch(mailbox_element_ptr mailbox_elem,
-                                strong_actor_ptr ctrl) {
+                                strong_actor_ptr ctrl,
+                                outgoing_message_queue& queue,
+                                serialize_fun_type sf) {
+  queue_ = &queue;
   msg_id_ = queue_->new_id();
   mailbox_elem_ = std::move(mailbox_elem);
   receiver_ = std::move(ctrl);
+  sf_ = sf;
   ref();
   system_->scheduler().enqueue(this);
 }

--- a/libcaf_net/src/serializing_worker.cpp
+++ b/libcaf_net/src/serializing_worker.cpp
@@ -19,40 +19,37 @@
 #include "caf/net/serializing_worker.hpp"
 
 #include "caf/actor_system.hpp"
-#include "caf/byte.hpp"
 #include "caf/net/basp/message_queue.hpp"
 #include "caf/proxy_registry.hpp"
-#include "caf/scheduler/abstract_coordinator.hpp"
 
 namespace caf::net {
 
 // -- constructors, destructors, and assignment operators ----------------------
-/*
+
 serializing_worker::serializing_worker(hub_type& hub, actor_system& sys,
+                                       outgoing_message_queue& queue,
                                        serialize_fun_type sf)
-  : hub_(&hub), system_(&sys), manager_(nullptr), sf_(sf) {
+  : msg_id_(0), hub_(&hub), system_(&sys), queue_(&queue), sf_(sf) {
   // nop
 }
 
 // -- management ---------------------------------------------------------------
 
 void serializing_worker::launch(mailbox_element_ptr mailbox_elem,
-                                strong_actor_ptr ctrl,
-                                endpoint_manager* manager) {
+                                strong_actor_ptr ctrl) {
+  msg_id_ = queue_->new_id();
   mailbox_elem_ = std::move(mailbox_elem);
   receiver_ = std::move(ctrl);
-  manager_ = manager;
   ref();
   system_->scheduler().enqueue(this);
 }
 
 // -- implementation of resumable ----------------------------------------------
 
-resumable::resume_result serializing_worker::resume(execution_unit* ctx,
-                                                    size_t) {
-  handle_outgoing_message(ctx);
+resumable::resume_result serializing_worker::resume(execution_unit*, size_t) {
+  this->handle_outgoing_message();
   hub_->push(this);
   return resumable::awaiting_message;
 }
-*/
+
 } // namespace caf::net

--- a/libcaf_net/src/serializing_worker.cpp
+++ b/libcaf_net/src/serializing_worker.cpp
@@ -27,7 +27,7 @@
 namespace caf::net {
 
 // -- constructors, destructors, and assignment operators ----------------------
-
+/*
 serializing_worker::serializing_worker(hub_type& hub, actor_system& sys,
                                        serialize_fun_type sf)
   : hub_(&hub), system_(&sys), manager_(nullptr), sf_(sf) {
@@ -54,5 +54,5 @@ resumable::resume_result serializing_worker::resume(execution_unit* ctx,
   hub_->push(this);
   return resumable::awaiting_message;
 }
-
+*/
 } // namespace caf::net

--- a/libcaf_net/src/serializing_worker.cpp
+++ b/libcaf_net/src/serializing_worker.cpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#include "caf/net/serializing_worker.hpp"
+
+#include "caf/actor_system.hpp"
+#include "caf/byte.hpp"
+#include "caf/net/basp/message_queue.hpp"
+#include "caf/proxy_registry.hpp"
+#include "caf/scheduler/abstract_coordinator.hpp"
+
+namespace caf::net {
+
+// -- constructors, destructors, and assignment operators ----------------------
+
+serializing_worker::serializing_worker(hub_type& hub, actor_system& sys)
+  : hub_(&hub), system_(&sys), ctrl_(nullptr), manager_(nullptr) {
+  // nop
+}
+
+// -- management ---------------------------------------------------------------
+
+void serializing_worker::launch(mailbox_element_ptr mailbox_elem,
+                                actor_control_block* ctrl,
+                                endpoint_manager* manager) {
+  mailbox_elem_ = std::move(mailbox_elem);
+  ctrl_ = ctrl;
+  manager_ = manager;
+  ref();
+  system_->scheduler().enqueue(this);
+}
+
+// -- implementation of resumable ----------------------------------------------
+
+resumable::resume_result serializing_worker::resume(execution_unit* ctx,
+                                                    size_t) {
+  handle_outgoing_message(ctx);
+  hub_->push(this);
+  return resumable::awaiting_message;
+}
+
+} // namespace caf::net

--- a/libcaf_net/src/worker.cpp
+++ b/libcaf_net/src/worker.cpp
@@ -28,8 +28,8 @@ namespace caf::net::basp {
 
 // -- constructors, destructors, and assignment operators ----------------------
 
-worker::worker(hub_type& hub, message_queue& queue, proxy_registry& proxies)
-  : hub_(&hub), queue_(&queue), proxies_(&proxies), system_(&proxies.system()) {
+worker::worker(hub_type& hub, actor_system& sys)
+  : hub_(&hub), queue_(nullptr), proxies_(nullptr), system_(&sys) {
   CAF_IGNORE_UNUSED(pad_);
 }
 
@@ -40,7 +40,10 @@ worker::~worker() {
 // -- management ---------------------------------------------------------------
 
 void worker::launch(const node_id& last_hop, const basp::header& hdr,
-                    span<const byte> payload) {
+                    span<const byte> payload, message_queue& queue,
+                    proxy_registry& proxies) {
+  queue_ = &queue;
+  proxies_ = &proxies;
   msg_id_ = queue_->new_id();
   last_hop_ = last_hop;
   memcpy(&hdr_, &hdr, sizeof(basp::header));

--- a/libcaf_net/test/application.cpp
+++ b/libcaf_net/test/application.cpp
@@ -48,7 +48,7 @@ struct fixture : test_coordinator_fixture<>,
                  public packet_writer {
   using buffer_type = std::vector<byte>;
 
-  fixture() : proxies(sys, *this), app(proxies) {
+  fixture() : proxies(sys, *this), app(proxies, hub) {
     REQUIRE_OK(app.init(*this));
     uri mars_uri;
     REQUIRE_OK(parse("tcp://mars", mars_uri));
@@ -148,6 +148,8 @@ protected:
   node_id mars;
 
   proxy_registry proxies;
+
+  detail::worker_hub<basp::worker> hub;
 
   basp::application app;
 };

--- a/libcaf_net/test/datagram_transport.cpp
+++ b/libcaf_net/test/datagram_transport.cpp
@@ -52,8 +52,8 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
   using buffer_ptr = std::shared_ptr<buffer_type>;
 
   fixture() : shared_buf(std::make_shared<buffer_type>(1024)) {
-    mpx = std::make_shared<multiplexer>(sys);
-    if (auto err = mpx->init())
+    mpx = std::make_shared<multiplexer>();
+    if (auto err = mpx->init(sys))
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     mpx->set_thread_id();
     CAF_CHECK_EQUAL(mpx->num_socket_managers(), 1u);

--- a/libcaf_net/test/datagram_transport.cpp
+++ b/libcaf_net/test/datagram_transport.cpp
@@ -101,6 +101,8 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
   ip_endpoint ep;
   udp_datagram_socket send_socket;
   udp_datagram_socket recv_socket;
+  // Don't add workers, this test should stay deterministic
+  detail::worker_hub<serializing_worker> hub;
 };
 
 class dummy_application {
@@ -208,7 +210,8 @@ CAF_TEST(receive) {
   auto mgr = make_endpoint_manager(mpx, sys,
                                    transport_type{recv_socket,
                                                   dummy_application_factory{
-                                                    shared_buf}});
+                                                    shared_buf}},
+                                   hub);
   CAF_CHECK_EQUAL(mgr->init(), none);
   auto mgr_impl = mgr.downcast<endpoint_manager_impl<transport_type>>();
   CAF_CHECK(mgr_impl != nullptr);
@@ -231,7 +234,8 @@ CAF_TEST(resolve and proxy communication) {
   auto mgr = make_endpoint_manager(mpx, sys,
                                    transport_type{send_socket,
                                                   dummy_application_factory{
-                                                    shared_buf}});
+                                                    shared_buf}},
+                                   hub);
   CAF_CHECK_EQUAL(mgr->init(), none);
   auto mgr_impl = mgr.downcast<endpoint_manager_impl<transport_type>>();
   CAF_CHECK(mgr_impl != nullptr);

--- a/libcaf_net/test/datagram_transport.cpp
+++ b/libcaf_net/test/datagram_transport.cpp
@@ -52,7 +52,7 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
   using buffer_ptr = std::shared_ptr<buffer_type>;
 
   fixture() : shared_buf(std::make_shared<buffer_type>(1024)) {
-    mpx = std::make_shared<multiplexer>();
+    mpx = std::make_shared<multiplexer>(sys);
     if (auto err = mpx->init())
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     mpx->set_thread_id();
@@ -101,8 +101,6 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
   ip_endpoint ep;
   udp_datagram_socket send_socket;
   udp_datagram_socket recv_socket;
-  // Don't add workers, this test should stay deterministic
-  detail::worker_hub<serializing_worker> hub;
 };
 
 class dummy_application {
@@ -210,8 +208,7 @@ CAF_TEST(receive) {
   auto mgr = make_endpoint_manager(mpx, sys,
                                    transport_type{recv_socket,
                                                   dummy_application_factory{
-                                                    shared_buf}},
-                                   hub);
+                                                    shared_buf}});
   CAF_CHECK_EQUAL(mgr->init(), none);
   auto mgr_impl = mgr.downcast<endpoint_manager_impl<transport_type>>();
   CAF_CHECK(mgr_impl != nullptr);
@@ -234,8 +231,7 @@ CAF_TEST(resolve and proxy communication) {
   auto mgr = make_endpoint_manager(mpx, sys,
                                    transport_type{send_socket,
                                                   dummy_application_factory{
-                                                    shared_buf}},
-                                   hub);
+                                                    shared_buf}});
   CAF_CHECK_EQUAL(mgr->init(), none);
   auto mgr_impl = mgr.downcast<endpoint_manager_impl<transport_type>>();
   CAF_CHECK(mgr_impl != nullptr);

--- a/libcaf_net/test/datagram_transport.cpp
+++ b/libcaf_net/test/datagram_transport.cpp
@@ -166,13 +166,12 @@ public:
     CAF_FAIL("handle_error called: " << to_string(sec));
   }
 
-  static expected<buffer_type> serialize(actor_system& sys,
-                                         const type_erased_tuple& x) {
-    buffer_type result;
-    binary_serializer sink{sys, result};
+  static error serialize(actor_system& sys, const type_erased_tuple& x,
+                         std::vector<byte>& buf) {
+    binary_serializer sink{sys, buf};
     if (auto err = message::save(sink, x))
       return err.value();
-    return result;
+    return none;
   }
 
 private:

--- a/libcaf_net/test/doorman.cpp
+++ b/libcaf_net/test/doorman.cpp
@@ -41,8 +41,8 @@ namespace {
 
 struct fixture : test_coordinator_fixture<>, host_fixture {
   fixture() {
-    mpx = std::make_shared<multiplexer>(sys);
-    if (auto err = mpx->init())
+    mpx = std::make_shared<multiplexer>();
+    if (auto err = mpx->init(sys))
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     mpx->set_thread_id();
     CAF_CHECK_EQUAL(mpx->num_socket_managers(), 1u);

--- a/libcaf_net/test/doorman.cpp
+++ b/libcaf_net/test/doorman.cpp
@@ -56,6 +56,8 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
 
   multiplexer_ptr mpx;
   uri::authority_type auth;
+  // Don't add workers, this test should stay deterministic
+  detail::worker_hub<serializing_worker> hub;
 };
 
 class dummy_application {
@@ -143,7 +145,8 @@ CAF_TEST(doorman accept) {
   auto mgr = make_endpoint_manager(
     mpx, sys,
     doorman<dummy_application_factory>{acceptor_guard.release(),
-                                       dummy_application_factory{}});
+                                       dummy_application_factory{}, hub},
+    hub);
   CAF_CHECK_EQUAL(mgr->init(), none);
   auto before = mpx->num_socket_managers();
   CAF_CHECK_EQUAL(before, 2u);

--- a/libcaf_net/test/doorman.cpp
+++ b/libcaf_net/test/doorman.cpp
@@ -60,13 +60,12 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
 
 class dummy_application {
 public:
-  static expected<std::vector<byte>> serialize(actor_system& sys,
-                                               const type_erased_tuple& x) {
-    std::vector<byte> result;
-    binary_serializer sink{sys, result};
+  static error serialize(actor_system& sys, const type_erased_tuple& x,
+                         std::vector<byte>& buf) {
+    binary_serializer sink{sys, buf};
     if (auto err = message::save(sink, x))
       return err.value();
-    return result;
+    return none;
   }
 
   template <class Parent>
@@ -116,9 +115,9 @@ class dummy_application_factory {
 public:
   using application_type = dummy_application;
 
-  static expected<std::vector<byte>> serialize(actor_system& sys,
-                                               const type_erased_tuple& x) {
-    return dummy_application::serialize(sys, x);
+  static error serialize(actor_system& sys, const type_erased_tuple& x,
+                         std::vector<byte>& buf) {
+    return dummy_application::serialize(sys, x, buf);
   }
 
   template <class Parent>

--- a/libcaf_net/test/doorman.cpp
+++ b/libcaf_net/test/doorman.cpp
@@ -41,7 +41,7 @@ namespace {
 
 struct fixture : test_coordinator_fixture<>, host_fixture {
   fixture() {
-    mpx = std::make_shared<multiplexer>();
+    mpx = std::make_shared<multiplexer>(sys);
     if (auto err = mpx->init())
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     mpx->set_thread_id();
@@ -56,8 +56,6 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
 
   multiplexer_ptr mpx;
   uri::authority_type auth;
-  // Don't add workers, this test should stay deterministic
-  detail::worker_hub<serializing_worker> hub;
 };
 
 class dummy_application {
@@ -145,8 +143,7 @@ CAF_TEST(doorman accept) {
   auto mgr = make_endpoint_manager(
     mpx, sys,
     doorman<dummy_application_factory>{acceptor_guard.release(),
-                                       dummy_application_factory{}, hub},
-    hub);
+                                       dummy_application_factory{}});
   CAF_CHECK_EQUAL(mgr->init(), none);
   auto before = mpx->num_socket_managers();
   CAF_CHECK_EQUAL(before, 2u);

--- a/libcaf_net/test/endpoint_manager.cpp
+++ b/libcaf_net/test/endpoint_manager.cpp
@@ -57,6 +57,9 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
   }
 
   multiplexer_ptr mpx;
+
+  // Don't add workers, this test should stay deterministic
+  detail::worker_hub<serializing_worker> hub;
 };
 
 class dummy_application {
@@ -172,7 +175,7 @@ CAF_TEST(send and receive) {
                   sec::unavailable_or_would_block);
   auto guard = detail::make_scope_guard([&] { close(sockets.second); });
   auto mgr = make_endpoint_manager(mpx, sys,
-                                   dummy_transport{sockets.first, buf});
+                                   dummy_transport{sockets.first, buf}, hub);
   CAF_CHECK_EQUAL(mgr->mask(), operation::none);
   CAF_CHECK_EQUAL(mgr->init(), none);
   CAF_CHECK_EQUAL(mgr->mask(), operation::read_write);
@@ -196,7 +199,7 @@ CAF_TEST(resolve and proxy communication) {
   nonblocking(sockets.second, true);
   auto guard = detail::make_scope_guard([&] { close(sockets.second); });
   auto mgr = make_endpoint_manager(mpx, sys,
-                                   dummy_transport{sockets.first, buf});
+                                   dummy_transport{sockets.first, buf}, hub);
   CAF_CHECK_EQUAL(mgr->init(), none);
   CAF_CHECK_EQUAL(mgr->mask(), operation::read_write);
   run();

--- a/libcaf_net/test/endpoint_manager.cpp
+++ b/libcaf_net/test/endpoint_manager.cpp
@@ -44,9 +44,9 @@ string_view hello_test{"hello test!"};
 
 struct fixture : test_coordinator_fixture<>, host_fixture {
   fixture() {
-    mpx = std::make_shared<multiplexer>(sys);
+    mpx = std::make_shared<multiplexer>();
     mpx->set_thread_id();
-    if (auto err = mpx->init())
+    if (auto err = mpx->init(sys))
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     if (mpx->num_socket_managers() != 1)
       CAF_FAIL("mpx->num_socket_managers() != 1");

--- a/libcaf_net/test/multiplexer.cpp
+++ b/libcaf_net/test/multiplexer.cpp
@@ -120,8 +120,8 @@ private:
 
 using dummy_manager_ptr = intrusive_ptr<dummy_manager>;
 
-struct fixture : host_fixture {
-  fixture() : manager_count(0), mpx(std::make_shared<multiplexer>()) {
+struct fixture : test_coordinator_fixture<>, host_fixture {
+  fixture() : manager_count(0), mpx(std::make_shared<multiplexer>(sys)) {
     mpx->set_thread_id();
   }
 

--- a/libcaf_net/test/multiplexer.cpp
+++ b/libcaf_net/test/multiplexer.cpp
@@ -121,7 +121,7 @@ private:
 using dummy_manager_ptr = intrusive_ptr<dummy_manager>;
 
 struct fixture : test_coordinator_fixture<>, host_fixture {
-  fixture() : manager_count(0), mpx(std::make_shared<multiplexer>(sys)) {
+  fixture() : manager_count(0), mpx(std::make_shared<multiplexer>()) {
     mpx->set_thread_id();
   }
 
@@ -150,7 +150,7 @@ CAF_TEST(default construction) {
 
 CAF_TEST(init) {
   CAF_CHECK_EQUAL(mpx->num_socket_managers(), 0u);
-  CAF_REQUIRE_EQUAL(mpx->init(), none);
+  CAF_REQUIRE_EQUAL(mpx->init(sys), none);
   CAF_CHECK_EQUAL(mpx->num_socket_managers(), 1u);
   mpx->close_pipe();
   exhaust();
@@ -160,7 +160,7 @@ CAF_TEST(init) {
 }
 
 CAF_TEST(send and receive) {
-  CAF_REQUIRE_EQUAL(mpx->init(), none);
+  CAF_REQUIRE_EQUAL(mpx->init(sys), none);
   auto sockets = unbox(make_stream_socket_pair());
   auto alice = make_counted<dummy_manager>(manager_count, sockets.first, mpx);
   auto bob = make_counted<dummy_manager>(manager_count, sockets.second, mpx);

--- a/libcaf_net/test/net/basp/worker.cpp
+++ b/libcaf_net/test/net/basp/worker.cpp
@@ -103,7 +103,7 @@ CAF_TEST_FIXTURE_SCOPE(worker_tests, fixture)
 CAF_TEST(deliver serialized message) {
   CAF_MESSAGE("create the BASP worker");
   CAF_REQUIRE_EQUAL(hub.peek(), nullptr);
-  hub.add_new_worker(queue, proxies);
+  hub.add_new_worker(sys);
   CAF_REQUIRE_NOT_EQUAL(hub.peek(), nullptr);
   auto w = hub.pop();
   CAF_MESSAGE("create a fake message + BASP header");
@@ -117,7 +117,7 @@ CAF_TEST(deliver serialized message) {
                         static_cast<uint32_t>(payload.size()),
                         make_message_id().integer_value()};
   CAF_MESSAGE("launch worker");
-  w->launch(last_hop, hdr, payload);
+  w->launch(last_hop, hdr, payload, queue, proxies);
   sched.run_once();
   expect((ok_atom), from(_).to(testee));
 }

--- a/libcaf_net/test/stream_transport.cpp
+++ b/libcaf_net/test/stream_transport.cpp
@@ -137,13 +137,12 @@ public:
     // nop
   }
 
-  static expected<buffer_type> serialize(actor_system& sys,
-                                         const type_erased_tuple& x) {
-    buffer_type result;
-    binary_serializer sink{sys, result};
+  static error serialize(actor_system& sys, const type_erased_tuple& x,
+                         std::vector<byte>& buf) {
+    binary_serializer sink{sys, buf};
     if (auto err = message::save(sink, x))
       return err.value();
-    return result;
+    return none;
   }
 
 private:

--- a/libcaf_net/test/stream_transport.cpp
+++ b/libcaf_net/test/stream_transport.cpp
@@ -49,8 +49,8 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
   using buffer_ptr = std::shared_ptr<buffer_type>;
 
   fixture() : recv_buf(1024), shared_buf{std::make_shared<buffer_type>()} {
-    mpx = std::make_shared<multiplexer>(sys);
-    if (auto err = mpx->init())
+    mpx = std::make_shared<multiplexer>();
+    if (auto err = mpx->init(sys))
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     mpx->set_thread_id();
     CAF_CHECK_EQUAL(mpx->num_socket_managers(), 1u);

--- a/libcaf_net/test/string_application.cpp
+++ b/libcaf_net/test/string_application.cpp
@@ -58,6 +58,9 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
   }
 
   multiplexer_ptr mpx;
+
+  // Don't add workers, this test should stay deterministic
+  detail::worker_hub<serializing_worker> hub;
 };
 
 struct string_application_header {
@@ -221,12 +224,14 @@ CAF_TEST(receive) {
   CAF_MESSAGE("adding both endpoint managers");
   auto mgr1 = make_endpoint_manager(mpx, sys,
                                     transport_type{sockets.first,
-                                                   application_type{sys, buf}});
+                                                   application_type{sys, buf}},
+                                    hub);
   CAF_CHECK_EQUAL(mgr1->init(), none);
   CAF_CHECK_EQUAL(mpx->num_socket_managers(), 2u);
   auto mgr2 = make_endpoint_manager(mpx, sys,
                                     transport_type{sockets.second,
-                                                   application_type{sys, buf}});
+                                                   application_type{sys, buf}},
+                                    hub);
   CAF_CHECK_EQUAL(mgr2->init(), none);
   CAF_CHECK_EQUAL(mpx->num_socket_managers(), 3u);
   CAF_MESSAGE("resolve actor-proxy");

--- a/libcaf_net/test/string_application.cpp
+++ b/libcaf_net/test/string_application.cpp
@@ -47,8 +47,8 @@ using buffer_type = std::vector<byte>;
 
 struct fixture : test_coordinator_fixture<>, host_fixture {
   fixture() {
-    mpx = std::make_shared<multiplexer>(sys);
-    if (auto err = mpx->init())
+    mpx = std::make_shared<multiplexer>();
+    if (auto err = mpx->init(sys))
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     mpx->set_thread_id();
   }

--- a/libcaf_net/test/string_application.cpp
+++ b/libcaf_net/test/string_application.cpp
@@ -112,13 +112,12 @@ public:
     parent.write_packet(header_buf, ptr->payload);
   }
 
-  static expected<std::vector<byte>> serialize(actor_system& sys,
-                                               const type_erased_tuple& x) {
-    std::vector<byte> result;
-    binary_serializer sink{sys, result};
+  static error serialize(actor_system& sys, const type_erased_tuple& x,
+                         std::vector<byte>& buf) {
+    binary_serializer sink{sys, buf};
     if (auto err = message::save(sink, x))
       return err.value();
-    return result;
+    return none;
   }
 
 private:

--- a/libcaf_net/test/string_application.cpp
+++ b/libcaf_net/test/string_application.cpp
@@ -47,7 +47,7 @@ using buffer_type = std::vector<byte>;
 
 struct fixture : test_coordinator_fixture<>, host_fixture {
   fixture() {
-    mpx = std::make_shared<multiplexer>();
+    mpx = std::make_shared<multiplexer>(sys);
     if (auto err = mpx->init())
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     mpx->set_thread_id();
@@ -58,9 +58,6 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
   }
 
   multiplexer_ptr mpx;
-
-  // Don't add workers, this test should stay deterministic
-  detail::worker_hub<serializing_worker> hub;
 };
 
 struct string_application_header {
@@ -224,14 +221,12 @@ CAF_TEST(receive) {
   CAF_MESSAGE("adding both endpoint managers");
   auto mgr1 = make_endpoint_manager(mpx, sys,
                                     transport_type{sockets.first,
-                                                   application_type{sys, buf}},
-                                    hub);
+                                                   application_type{sys, buf}});
   CAF_CHECK_EQUAL(mgr1->init(), none);
   CAF_CHECK_EQUAL(mpx->num_socket_managers(), 2u);
   auto mgr2 = make_endpoint_manager(mpx, sys,
                                     transport_type{sockets.second,
-                                                   application_type{sys, buf}},
-                                    hub);
+                                                   application_type{sys, buf}});
   CAF_CHECK_EQUAL(mgr2->init(), none);
   CAF_CHECK_EQUAL(mpx->num_socket_managers(), 3u);
   CAF_MESSAGE("resolve actor-proxy");

--- a/libcaf_net/test/transport_worker.cpp
+++ b/libcaf_net/test/transport_worker.cpp
@@ -158,7 +158,7 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
       application_results{std::make_shared<application_result>()},
       transport(transport_results),
       worker{dummy_application{application_results}} {
-    mpx = std::make_shared<multiplexer>();
+    mpx = std::make_shared<multiplexer>(sys);
     if (auto err = mpx->init())
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     if (auto err = parse("[::1]:12345", ep))

--- a/libcaf_net/test/transport_worker.cpp
+++ b/libcaf_net/test/transport_worker.cpp
@@ -158,8 +158,8 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
       application_results{std::make_shared<application_result>()},
       transport(transport_results),
       worker{dummy_application{application_results}} {
-    mpx = std::make_shared<multiplexer>(sys);
-    if (auto err = mpx->init())
+    mpx = std::make_shared<multiplexer>();
+    if (auto err = mpx->init(sys))
       CAF_FAIL("mpx->init failed: " << sys.render(err));
     if (auto err = parse("[::1]:12345", ep))
       CAF_FAIL("parse returned an error: " << err);


### PR DESCRIPTION
This PR adds workers for serializing outgoing messages.
With this change there are currently two similar types of workers. We should think about merging them and  removing the two similar implementations.
