### PR TITLE
Fix bug in tcp_stream_socket

### DIFF
--- a/libcaf_net/src/tcp_stream_socket.cpp
+++ b/libcaf_net/src/tcp_stream_socket.cpp
@@ -83,7 +83,7 @@ make_connected_tcp_stream_socket(const uri::authority_type& node) {
     return make_error(sec::cannot_connect_to_node, "port is zero");
   std::vector<ip_address> addrs;
   if (auto str = get_if<std::string>(&node.host))
-    addrs = ip::local_addresses(*str);
+    addrs = ip::resolve(*str);
   else if (auto addr = get_if<ip_address>(&node.host))
     addrs.push_back(*addr);
   if (addrs.empty())


### PR DESCRIPTION
This fixes a bug in `make_connected_tcp_stream_socket` which lead to not being able to resolve remote hosts on connect.