### PR TITLE
Move serialization to multiplexer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(CAF_INC_ENABLE_STANDALONE_BUILD)
   FetchContent_Declare(
     actor_framework
     GIT_REPOSITORY https://github.com/actor-framework/actor-framework.git
-    GIT_TAG        d7f70e997
+    GIT_TAG        94e26b315
   )
   FetchContent_Populate(actor_framework)
   set(CAF_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)

--- a/libcaf_net/caf/net/actor_proxy_impl.hpp
+++ b/libcaf_net/caf/net/actor_proxy_impl.hpp
@@ -37,7 +37,6 @@ public:
   void kill_proxy(execution_unit* ctx, error rsn) override;
 
 private:
-  endpoint_manager::serialize_fun_type sf_;
   endpoint_manager_ptr dst_;
 };
 

--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -136,9 +136,6 @@ public:
     // nop
   }
 
-  static error_code<sec> serialize(actor_system& sys, const message& x,
-                                   std::vector<byte>& buf);
-
   // -- utility functions ------------------------------------------------------
 
   strong_actor_ptr resolve_local_path(string_view path);

--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -136,7 +136,8 @@ public:
     // nop
   }
 
-  static expected<buffer_type> serialize(actor_system& sys, const message& x);
+  static error_code<sec> serialize(actor_system& sys, const message& x,
+                                   std::vector<byte>& buf);
 
   // -- utility functions ------------------------------------------------------
 

--- a/libcaf_net/caf/net/endpoint_manager.hpp
+++ b/libcaf_net/caf/net/endpoint_manager.hpp
@@ -71,8 +71,7 @@ public:
   void resolve(uri locator, actor listener);
 
   /// Enqueues a message to the endpoint.
-  void enqueue(mailbox_element_ptr msg, strong_actor_ptr receiver,
-               std::vector<byte> payload);
+  void enqueue(mailbox_element_ptr msg, strong_actor_ptr receiver);
 
   /// Enqueues an event to the endpoint.
   template <class... Ts>

--- a/libcaf_net/caf/net/endpoint_manager.hpp
+++ b/libcaf_net/caf/net/endpoint_manager.hpp
@@ -44,11 +44,9 @@ public:
 
   using super = socket_manager;
 
-  /// Represents either an error or a serialized payload.
-  using maybe_buffer = expected<std::vector<byte>>;
-
   /// A function type for serializing message payloads.
-  using serialize_fun_type = maybe_buffer (*)(actor_system&, const message&);
+  using serialize_fun_type = error_code<sec> (*)(actor_system&, const message&,
+                                                 std::vector<byte>& buf);
 
   // -- constructors, destructors, and assignment operators --------------------
 

--- a/libcaf_net/caf/net/endpoint_manager.hpp
+++ b/libcaf_net/caf/net/endpoint_manager.hpp
@@ -44,10 +44,6 @@ public:
 
   using super = socket_manager;
 
-  /// A function type for serializing message payloads.
-  using serialize_fun_type = error_code<sec> (*)(actor_system&, const message&,
-                                                 std::vector<byte>& buf);
-
   // -- constructors, destructors, and assignment operators --------------------
 
   endpoint_manager(socket handle, const multiplexer_ptr& parent,
@@ -81,9 +77,6 @@ public:
 
   /// Initializes the manager before adding it to the multiplexer's event loop.
   virtual error init() = 0;
-
-  /// @returns the protocol-specific function for serializing payloads.
-  virtual serialize_fun_type serialize_fun() const noexcept = 0;
 
 protected:
   bool enqueue(endpoint_manager_queue::element* ptr);

--- a/libcaf_net/caf/net/endpoint_manager_impl.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_impl.hpp
@@ -62,8 +62,8 @@ public:
   // -- timeout management -----------------------------------------------------
 
   template <class... Ts>
-  uint64_t set_timeout(actor_clock::time_point tp, std::string type,
-                       Ts&&... xs) {
+  uint64_t
+  set_timeout(actor_clock::time_point tp, std::string type, Ts&&... xs) {
     auto act = actor_cast<abstract_actor*>(timeout_proxy_);
     CAF_ASSERT(act != nullptr);
     sys_.clock().set_multi_timeout(tp, act, std::move(type), next_timeout_id_);
@@ -117,10 +117,6 @@ public:
 
   void handle_error(sec code) override {
     transport_.handle_error(code);
-  }
-
-  serialize_fun_type serialize_fun() const noexcept override {
-    return application_type::serialize;
   }
 
 private:

--- a/libcaf_net/caf/net/endpoint_manager_queue.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_queue.hpp
@@ -125,11 +125,7 @@ public:
     /// ID of the receiving actor.
     strong_actor_ptr receiver;
 
-    /// Serialized representation of of `msg->content()`.
-    std::vector<byte> payload;
-
-    message(mailbox_element_ptr msg, strong_actor_ptr receiver,
-            std::vector<byte> payload);
+    message(mailbox_element_ptr msg, strong_actor_ptr receiver);
 
     ~message() override;
 
@@ -153,9 +149,10 @@ public:
       // nop
     }
 
-    static task_size_type task_size(const message& x) noexcept {
+    static task_size_type task_size(const message&) noexcept {
       // Return at least 1 if the payload is empty.
-      return x.payload.size() + static_cast<task_size_type>(x.payload.empty());
+      return static_cast<task_size_type>(1);
+      // was x.payload.size() + static_cast<task_size_type>(x.payload.empty());
     }
   };
 

--- a/libcaf_net/caf/net/endpoint_manager_queue.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_queue.hpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "caf/actor.hpp"
+#include "caf/detail/serialized_size.hpp"
 #include "caf/fwd.hpp"
 #include "caf/intrusive/drr_queue.hpp"
 #include "caf/intrusive/fifo_inbox.hpp"
@@ -149,8 +150,8 @@ public:
       // nop
     }
 
-    static constexpr task_size_type task_size(const message&) noexcept {
-      return 1;
+    static task_size_type task_size(const message& msg) noexcept {
+      return detail::serialized_size(msg.msg->content());
     }
   };
 

--- a/libcaf_net/caf/net/endpoint_manager_queue.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_queue.hpp
@@ -112,7 +112,7 @@ public:
       // nop
     }
 
-    task_size_type task_size(const event&) const noexcept {
+    static constexpr task_size_type task_size(const event&) noexcept {
       return 1;
     }
   };
@@ -149,10 +149,8 @@ public:
       // nop
     }
 
-    static task_size_type task_size(const message&) noexcept {
-      // Return at least 1 if the payload is empty.
-      return static_cast<task_size_type>(1);
-      // was x.payload.size() + static_cast<task_size_type>(x.payload.empty());
+    static constexpr task_size_type task_size(const message&) noexcept {
+      return 1;
     }
   };
 

--- a/libcaf_net/src/actor_proxy_impl.cpp
+++ b/libcaf_net/src/actor_proxy_impl.cpp
@@ -34,14 +34,11 @@ actor_proxy_impl::~actor_proxy_impl() {
   // nop
 }
 
-void actor_proxy_impl::enqueue(mailbox_element_ptr what, execution_unit*) {
+void actor_proxy_impl::enqueue(mailbox_element_ptr msg, execution_unit*) {
   CAF_PUSH_AID(0);
-  CAF_ASSERT(what != nullptr);
-  CAF_LOG_SEND_EVENT(what);
-  if (auto payload = sf_(home_system(), what->content()))
-    dst_->enqueue(std::move(what), ctrl(), std::move(*payload));
-  else
-    CAF_LOG_ERROR("unable to serialize payload: " << payload.error());
+  CAF_ASSERT(msg != nullptr);
+  CAF_LOG_SEND_EVENT(msg);
+  dst_->enqueue(std::move(msg), ctrl());
 }
 
 void actor_proxy_impl::kill_proxy(execution_unit* ctx, error rsn) {

--- a/libcaf_net/src/actor_proxy_impl.cpp
+++ b/libcaf_net/src/actor_proxy_impl.cpp
@@ -25,7 +25,7 @@
 namespace caf::net {
 
 actor_proxy_impl::actor_proxy_impl(actor_config& cfg, endpoint_manager_ptr dst)
-  : super(cfg), sf_(dst->serialize_fun()), dst_(std::move(dst)) {
+  : super(cfg), dst_(std::move(dst)) {
   CAF_ASSERT(dst_ != nullptr);
   dst_->enqueue_event(node(), id());
 }

--- a/libcaf_net/src/endpoint_manager.cpp
+++ b/libcaf_net/src/endpoint_manager.cpp
@@ -60,11 +60,9 @@ void endpoint_manager::resolve(uri locator, actor listener) {
 }
 
 void endpoint_manager::enqueue(mailbox_element_ptr msg,
-                               strong_actor_ptr receiver,
-                               std::vector<byte> payload) {
+                               strong_actor_ptr receiver) {
   using message_type = endpoint_manager_queue::message;
-  auto ptr = new message_type(std::move(msg), std::move(receiver),
-                              std::move(payload));
+  auto ptr = new message_type(std::move(msg), std::move(receiver));
   enqueue(ptr);
 }
 

--- a/libcaf_net/src/net/endpoint_manager_queue.cpp
+++ b/libcaf_net/src/net/endpoint_manager_queue.cpp
@@ -56,12 +56,10 @@ size_t endpoint_manager_queue::event::task_size() const noexcept {
 }
 
 endpoint_manager_queue::message::message(mailbox_element_ptr msg,
-                                         strong_actor_ptr receiver,
-                                         std::vector<byte> payload)
+                                         strong_actor_ptr receiver)
   : element(element_type::message),
     msg(std::move(msg)),
-    receiver(std::move(receiver)),
-    payload(std::move(payload)) {
+    receiver(std::move(receiver)) {
   // nop
 }
 

--- a/libcaf_net/test/datagram_transport.cpp
+++ b/libcaf_net/test/datagram_transport.cpp
@@ -123,7 +123,8 @@ public:
   void write_message(Parent& parent,
                      std::unique_ptr<endpoint_manager_queue::message> msg) {
     auto payload_buf = parent.next_payload_buffer();
-    if (auto err = serialize(parent.system(), msg->msg->payload, payload_buf))
+    binary_serializer sink{parent.system(), payload_buf};
+    if (auto err = sink(msg->msg->payload))
       CAF_FAIL("serializing failed: " << err);
     parent.write_packet(payload_buf);
   }
@@ -165,12 +166,6 @@ public:
 
   void handle_error(sec sec) {
     CAF_FAIL("handle_error called: " << to_string(sec));
-  }
-
-  static error_code<sec> serialize(actor_system& sys, const message& x,
-                                   std::vector<byte>& buf) {
-    binary_serializer sink{sys, buf};
-    return x.save(sink);
   }
 
 private:

--- a/libcaf_net/test/datagram_transport.cpp
+++ b/libcaf_net/test/datagram_transport.cpp
@@ -119,13 +119,13 @@ public:
     return none;
   }
 
-  template <class Transport>
-  void write_message(Transport& transport,
+  template <class Parent>
+  void write_message(Parent& parent,
                      std::unique_ptr<endpoint_manager_queue::message> msg) {
-    if (auto payload = serialize(transport.system(), msg->msg->payload))
-      transport.write_packet(*payload);
-    else
-      CAF_FAIL("serializing failed: " << payload.error());
+    auto payload_buf = parent.next_payload_buffer();
+    if (auto err = serialize(parent.system(), msg->msg->payload, payload_buf))
+      CAF_FAIL("serializing failed: " << err);
+    parent.write_packet(payload_buf);
   }
 
   template <class Parent>
@@ -167,12 +167,10 @@ public:
     CAF_FAIL("handle_error called: " << to_string(sec));
   }
 
-  static expected<buffer_type> serialize(actor_system& sys, const message& x) {
-    buffer_type result;
-    binary_serializer sink{sys, result};
-    if (auto err = x.save(sink))
-      return err.value();
-    return result;
+  static error_code<sec> serialize(actor_system& sys, const message& x,
+                                   std::vector<byte>& buf) {
+    binary_serializer sink{sys, buf};
+    return x.save(sink);
   }
 
 private:

--- a/libcaf_net/test/doorman.cpp
+++ b/libcaf_net/test/doorman.cpp
@@ -60,13 +60,10 @@ struct fixture : test_coordinator_fixture<>, host_fixture {
 
 class dummy_application {
 public:
-  static expected<std::vector<byte>> serialize(actor_system& sys,
-                                               const message& x) {
-    std::vector<byte> result;
-    binary_serializer sink{sys, result};
-    if (auto err = x.save(sink))
-      return err.value();
-    return result;
+  static error_code<sec> serialize(actor_system& sys, const message& x,
+                                   std::vector<byte>& buf) {
+    binary_serializer sink{sys, buf};
+    return x.save(sink);
   }
 
   template <class Parent>
@@ -74,13 +71,13 @@ public:
     return none;
   }
 
-  template <class Transport>
-  void write_message(Transport& transport,
+  template <class Parent>
+  void write_message(Parent& parent,
                      std::unique_ptr<endpoint_manager_queue::message> msg) {
-    if (auto payload = serialize(transport.system(), msg->msg->payload))
-      transport.write_packet(*payload);
-    else
-      CAF_FAIL("serializing failed: " << payload.error());
+    auto payload_buf = parent.next_payload_buffer();
+    if (auto err = serialize(parent.system(), msg->msg->payload, payload_buf))
+      CAF_FAIL("serializing failed: " << err);
+    parent.write_packet(payload_buf);
   }
 
   template <class Parent>
@@ -119,9 +116,9 @@ class dummy_application_factory {
 public:
   using application_type = dummy_application;
 
-  static expected<std::vector<byte>> serialize(actor_system& sys,
-                                               const message& x) {
-    return dummy_application::serialize(sys, x);
+  static error_code<sec> serialize(actor_system& sys, const message& x,
+                                   std::vector<byte>& buf) {
+    return dummy_application::serialize(sys, x, buf);
   }
 
   template <class Parent>

--- a/libcaf_net/test/doorman.cpp
+++ b/libcaf_net/test/doorman.cpp
@@ -74,10 +74,13 @@ public:
     return none;
   }
 
-  template <class Parent>
-  void write_message(Parent& parent,
+  template <class Transport>
+  void write_message(Transport& transport,
                      std::unique_ptr<endpoint_manager_queue::message> msg) {
-    parent.write_packet(msg->payload);
+    if (auto payload = serialize(transport.system(), msg->msg->payload))
+      transport.write_packet(*payload);
+    else
+      CAF_FAIL("serializing failed: " << payload.error());
   }
 
   template <class Parent>

--- a/libcaf_net/test/stream_transport.cpp
+++ b/libcaf_net/test/stream_transport.cpp
@@ -94,7 +94,8 @@ public:
   void write_message(Parent& parent,
                      std::unique_ptr<endpoint_manager_queue::message> msg) {
     auto payload_buf = parent.next_payload_buffer();
-    if (auto err = serialize(parent.system(), msg->msg->payload, payload_buf))
+    binary_serializer sink{parent.system(), payload_buf};
+    if (auto err = sink(msg->msg->payload))
       CAF_FAIL("serializing failed: " << err);
     parent.write_packet(payload_buf);
   }
@@ -136,12 +137,6 @@ public:
 
   void handle_error(sec) {
     // nop
-  }
-
-  static error_code<sec> serialize(actor_system& sys, const message& x,
-                                   std::vector<byte>& buf) {
-    binary_serializer sink{sys, buf};
-    return x.save(sink);
   }
 
 private:

--- a/libcaf_net/test/transport_worker_dispatcher.cpp
+++ b/libcaf_net/test/transport_worker_dispatcher.cpp
@@ -289,7 +289,8 @@ CAF_TEST(handle_data) {
   CHECK_HANDLE_DATA(test_data.at(3));
 }
 
-/*CAF_TEST(write_message write_packet) {
+/*
+  CAF_TEST(write_message write_packet) {
   CHECK_WRITE_MESSAGE(test_data.at(0));
   CHECK_WRITE_MESSAGE(test_data.at(1));
   CHECK_WRITE_MESSAGE(test_data.at(2));


### PR DESCRIPTION
The process of serializing outgoing messages is currently done before enqueueing data to the `endpoint_manager`. Hence, it is done in the thread of the actor that sends data.
This PR moves the serializing into the multiplexer thread and allows to reuse message buffers, which improves throughput of a simple streaming benchmark by about 20%.