### PR TITLE
Add tcp_backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(CAF_INC_ENABLE_STANDALONE_BUILD)
   FetchContent_Declare(
     actor_framework
     GIT_REPOSITORY https://github.com/actor-framework/actor-framework.git
-    GIT_TAG        94e26b315
+    GIT_TAG        e3f7e64c8
   )
   FetchContent_Populate(actor_framework)
   set(CAF_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(libcaf_net_obj OBJECT ${CAF_NET_HEADERS}
   src/ip.cpp
   src/message_queue.cpp
   src/multiplexer.cpp
+  src/net/backend/tcp.cpp
   src/net/backend/test.cpp
   src/net/endpoint_manager_queue.cpp
   src/net/middleman.cpp

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -35,7 +35,7 @@ endfunction()
 
 add_library(libcaf_net_obj OBJECT ${CAF_NET_HEADERS}
   src/actor_proxy_impl.cpp
-  src/application.cpp
+  src/basp/application.cpp
   src/basp/connection_state_strings.cpp
   src/basp/ec_strings.cpp
   src/basp/message_type_strings.cpp

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -16,7 +16,7 @@ caf_incubator_add_enum_consistency_check("caf/net/operation.hpp"
 # -- utility function for setting default properties ---------------------------
 
 function(caf_net_set_default_properties)
-  foreach (target ${ARGN})
+  foreach(target ${ARGN})
     caf_incubator_set_default_properties(${target})
     # Make sure we find our headers plus the the generated export header.
     target_include_directories(${target} PRIVATE
@@ -25,48 +25,48 @@ function(caf_net_set_default_properties)
     target_compile_definitions(${target} PRIVATE libcaf_net_EXPORTS)
     # Pull in public dependencies.
     target_link_libraries(${target} PUBLIC CAF::core)
-    if (MSVC)
+    if(MSVC)
       target_link_libraries(${target} PUBLIC ws2_32 iphlpapi)
-    endif ()
-  endforeach ()
+    endif()
+  endforeach()
 endfunction()
 
 # -- add library targets -------------------------------------------------------
 
 add_library(libcaf_net_obj OBJECT ${CAF_NET_HEADERS}
-            src/actor_proxy_impl.cpp
-            src/basp/application.cpp
-            src/basp/connection_state_strings.cpp
-            src/basp/ec_strings.cpp
-            src/basp/message_type_strings.cpp
-            src/basp/operation_strings.cpp
-            src/convert_ip_endpoint.cpp
-            src/datagram_socket.cpp
-            src/defaults.cpp
-            src/defaults.cpp
-            src/endpoint_manager.cpp
-            src/header.cpp
-            src/host.cpp
-            src/ip.cpp
-            src/message_queue.cpp
-            src/multiplexer.cpp
-            src/net/backend/tcp.cpp
-            src/net/backend/test.cpp
-            src/net/endpoint_manager_queue.cpp
-            src/net/middleman.cpp
-            src/net/middleman_backend.cpp
-            src/net/packet_writer.cpp
-            src/network_socket.cpp
-            src/pipe_socket.cpp
-            src/pollset_updater.cpp
-            src/socket.cpp
-            src/socket_manager.cpp
-            src/stream_socket.cpp
-            src/tcp_accept_socket.cpp
-            src/tcp_stream_socket.cpp
-            src/udp_datagram_socket.cpp
-            src/worker.cpp
-            )
+  src/actor_proxy_impl.cpp
+  src/application.cpp
+  src/basp/connection_state_strings.cpp
+  src/basp/ec_strings.cpp
+  src/basp/message_type_strings.cpp
+  src/basp/operation_strings.cpp
+  src/convert_ip_endpoint.cpp
+  src/datagram_socket.cpp
+  src/defaults.cpp
+  src/defaults.cpp
+  src/endpoint_manager.cpp
+  src/header.cpp
+  src/host.cpp
+  src/ip.cpp
+  src/message_queue.cpp
+  src/multiplexer.cpp
+  src/net/backend/test.cpp
+  src/net/backend/tcp.cpp
+  src/net/endpoint_manager_queue.cpp
+  src/net/middleman.cpp
+  src/net/middleman_backend.cpp
+  src/net/packet_writer.cpp
+  src/network_socket.cpp
+  src/pipe_socket.cpp
+  src/pollset_updater.cpp
+  src/socket.cpp
+  src/socket_manager.cpp
+  src/stream_socket.cpp
+  src/tcp_accept_socket.cpp
+  src/tcp_stream_socket.cpp
+  src/udp_datagram_socket.cpp
+  src/worker.cpp
+)
 
 add_library(libcaf_net "${PROJECT_SOURCE_DIR}/cmake/dummy.cpp"
             $<TARGET_OBJECTS:libcaf_net_obj>)
@@ -80,7 +80,7 @@ set_property(TARGET libcaf_net_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 caf_net_set_default_properties(libcaf_net_obj libcaf_net)
 
 target_include_directories(libcaf_net INTERFACE
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 add_library(CAF::net ALIAS libcaf_net)
 
@@ -108,9 +108,9 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/caf"
 
 # -- build unit tests ----------------------------------------------------------
 
-if (NOT CAF_INC_ENABLE_TESTING)
+if(NOT CAF_INC_ENABLE_TESTING)
   return()
-endif ()
+endif()
 
 add_executable(caf-net-test
                test/net-test.cpp
@@ -123,30 +123,30 @@ target_include_directories(caf-net-test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tes
 target_link_libraries(caf-net-test PRIVATE CAF::test)
 
 caf_incubator_add_test_suites(caf-net-test
-                              net.basp.message_queue
-                              net.basp.ping_pong
-                              net.basp.worker
-                              accept_socket
-                              pipe_socket
-                              application
-                              socket
-                              convert_ip_endpoint
-                              socket_guard
-                              datagram_socket
-                              stream_application
-                              datagram_transport
-                              stream_socket
-                              doorman
-                              stream_transport
-                              endpoint_manager
-                              string_application
-                              header
-                              tcp_sockets
-                              ip
-                              transport_worker
-                              multiplexer
-                              transport_worker_dispatcher
-                              udp_datagram_socket
-                              network_socket
-                              net.backend.tcp
-                              )
+  net.basp.message_queue
+  net.basp.ping_pong
+  net.basp.worker
+  accept_socket
+  pipe_socket
+  application
+  socket
+  convert_ip_endpoint
+  socket_guard
+  datagram_socket
+  stream_application
+  datagram_transport
+  stream_socket
+  doorman
+  stream_transport
+  endpoint_manager
+  string_application
+  header
+  tcp_sockets
+  ip
+  transport_worker
+  multiplexer
+  transport_worker_dispatcher
+  udp_datagram_socket
+  network_socket
+  net.backend.tcp
+)

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -148,4 +148,5 @@ caf_incubator_add_test_suites(caf-net-test
   transport_worker_dispatcher
   udp_datagram_socket
   network_socket
+  net.backend.tcp
 )

--- a/libcaf_net/CMakeLists.txt
+++ b/libcaf_net/CMakeLists.txt
@@ -16,7 +16,7 @@ caf_incubator_add_enum_consistency_check("caf/net/operation.hpp"
 # -- utility function for setting default properties ---------------------------
 
 function(caf_net_set_default_properties)
-  foreach(target ${ARGN})
+  foreach (target ${ARGN})
     caf_incubator_set_default_properties(${target})
     # Make sure we find our headers plus the the generated export header.
     target_include_directories(${target} PRIVATE
@@ -25,48 +25,48 @@ function(caf_net_set_default_properties)
     target_compile_definitions(${target} PRIVATE libcaf_net_EXPORTS)
     # Pull in public dependencies.
     target_link_libraries(${target} PUBLIC CAF::core)
-    if(MSVC)
+    if (MSVC)
       target_link_libraries(${target} PUBLIC ws2_32 iphlpapi)
-    endif()
-  endforeach()
+    endif ()
+  endforeach ()
 endfunction()
 
 # -- add library targets -------------------------------------------------------
 
 add_library(libcaf_net_obj OBJECT ${CAF_NET_HEADERS}
-  src/actor_proxy_impl.cpp
-  src/application.cpp
-  src/basp/connection_state_strings.cpp
-  src/basp/ec_strings.cpp
-  src/basp/message_type_strings.cpp
-  src/basp/operation_strings.cpp
-  src/convert_ip_endpoint.cpp
-  src/datagram_socket.cpp
-  src/defaults.cpp
-  src/defaults.cpp
-  src/endpoint_manager.cpp
-  src/header.cpp
-  src/host.cpp
-  src/ip.cpp
-  src/message_queue.cpp
-  src/multiplexer.cpp
-  src/net/backend/tcp.cpp
-  src/net/backend/test.cpp
-  src/net/endpoint_manager_queue.cpp
-  src/net/middleman.cpp
-  src/net/middleman_backend.cpp
-  src/net/packet_writer.cpp
-  src/network_socket.cpp
-  src/pipe_socket.cpp
-  src/pollset_updater.cpp
-  src/socket.cpp
-  src/socket_manager.cpp
-  src/stream_socket.cpp
-  src/tcp_accept_socket.cpp
-  src/tcp_stream_socket.cpp
-  src/udp_datagram_socket.cpp
-  src/worker.cpp
-)
+            src/actor_proxy_impl.cpp
+            src/basp/application.cpp
+            src/basp/connection_state_strings.cpp
+            src/basp/ec_strings.cpp
+            src/basp/message_type_strings.cpp
+            src/basp/operation_strings.cpp
+            src/convert_ip_endpoint.cpp
+            src/datagram_socket.cpp
+            src/defaults.cpp
+            src/defaults.cpp
+            src/endpoint_manager.cpp
+            src/header.cpp
+            src/host.cpp
+            src/ip.cpp
+            src/message_queue.cpp
+            src/multiplexer.cpp
+            src/net/backend/tcp.cpp
+            src/net/backend/test.cpp
+            src/net/endpoint_manager_queue.cpp
+            src/net/middleman.cpp
+            src/net/middleman_backend.cpp
+            src/net/packet_writer.cpp
+            src/network_socket.cpp
+            src/pipe_socket.cpp
+            src/pollset_updater.cpp
+            src/socket.cpp
+            src/socket_manager.cpp
+            src/stream_socket.cpp
+            src/tcp_accept_socket.cpp
+            src/tcp_stream_socket.cpp
+            src/udp_datagram_socket.cpp
+            src/worker.cpp
+            )
 
 add_library(libcaf_net "${PROJECT_SOURCE_DIR}/cmake/dummy.cpp"
             $<TARGET_OBJECTS:libcaf_net_obj>)
@@ -80,7 +80,7 @@ set_property(TARGET libcaf_net_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 caf_net_set_default_properties(libcaf_net_obj libcaf_net)
 
 target_include_directories(libcaf_net INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 add_library(CAF::net ALIAS libcaf_net)
 
@@ -108,9 +108,9 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/caf"
 
 # -- build unit tests ----------------------------------------------------------
 
-if(NOT CAF_INC_ENABLE_TESTING)
+if (NOT CAF_INC_ENABLE_TESTING)
   return()
-endif()
+endif ()
 
 add_executable(caf-net-test
                test/net-test.cpp
@@ -123,30 +123,30 @@ target_include_directories(caf-net-test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tes
 target_link_libraries(caf-net-test PRIVATE CAF::test)
 
 caf_incubator_add_test_suites(caf-net-test
-  net.basp.message_queue
-  net.basp.ping_pong
-  net.basp.worker
-  accept_socket
-  pipe_socket
-  application
-  socket
-  convert_ip_endpoint
-  socket_guard
-  datagram_socket
-  stream_application
-  datagram_transport
-  stream_socket
-  doorman
-  stream_transport
-  endpoint_manager
-  string_application
-  header
-  tcp_sockets
-  ip
-  transport_worker
-  multiplexer
-  transport_worker_dispatcher
-  udp_datagram_socket
-  network_socket
-  net.backend.tcp
-)
+                              net.basp.message_queue
+                              net.basp.ping_pong
+                              net.basp.worker
+                              accept_socket
+                              pipe_socket
+                              application
+                              socket
+                              convert_ip_endpoint
+                              socket_guard
+                              datagram_socket
+                              stream_application
+                              datagram_transport
+                              stream_socket
+                              doorman
+                              stream_transport
+                              endpoint_manager
+                              string_application
+                              header
+                              tcp_sockets
+                              ip
+                              transport_worker
+                              multiplexer
+                              transport_worker_dispatcher
+                              udp_datagram_socket
+                              network_socket
+                              net.backend.tcp
+                              )

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -37,7 +37,6 @@
 namespace caf::net::backend {
 
 /// Minimal backend for tcp communication.
-/// @warning this backend is *not* thread safe.
 class CAF_NET_EXPORT tcp : public middleman_backend {
 public:
   using peer_map = std::map<node_id, endpoint_manager_ptr>;

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -106,6 +106,7 @@ private:
       CAF_RAISE_ERROR("mgr->init() failed");
     }
     mpx->register_reading(mgr);
+    peers_.emplace(peer_id, std::move(mgr));
     return peers_[peer_id];
   }
 

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -90,25 +90,6 @@ public:
   }
 
 private:
-  class basp_application_factory {
-  public:
-    using application_type = basp::application;
-
-    basp_application_factory(proxy_registry& proxies);
-
-    template <class Parent>
-    error init(Parent&) {
-      return none;
-    }
-
-    application_type make() const {
-      return application_type{proxies_};
-    }
-
-  private:
-    proxy_registry& proxies_;
-  };
-
   endpoint_manager_ptr get_peer(const node_id& id);
 
   middleman& mm_;

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -85,7 +85,7 @@ public:
       return err;
     }
     mpx->register_reading(mgr);
-    peers_.emplace(peer_id, std::move(mgr));
+    peers_[peer_id] = std::move(mgr);
     return peers_[peer_id];
   }
 

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -53,7 +53,7 @@ public:
 
   endpoint_manager_ptr peer(const node_id& id) override;
 
-  void publish(actor handle, const uri& locator) override;
+  void publish(actor handle, string_view path) override;
 
   void resolve(const uri& locator, const actor& listener) override;
 

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -49,7 +49,7 @@ public:
 
   void stop() override;
 
-  endpoint_manager_ptr connect(const uri& locator);
+  endpoint_manager_ptr connect(const uri& locator) override;
 
   endpoint_manager_ptr peer(const node_id& id) override;
 
@@ -79,7 +79,6 @@ private:
     using application_type = basp::application;
 
     basp_application_factory(proxy_registry& proxies);
-    ~basp_application_factory();
 
     template <class Parent>
     error init(Parent&) {

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -53,15 +53,11 @@ public:
 
   endpoint_manager_ptr peer(const node_id& id) override;
 
-  void publish(actor handle, string_view path) override;
-
   void resolve(const uri& locator, const actor& listener) override;
 
   strong_actor_ptr make_proxy(node_id nid, actor_id aid) override;
 
   void set_last_hop(node_id*) override;
-
-  void publish();
 
   // -- properties -------------------------------------------------------------
 

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -87,10 +87,10 @@ public:
     emplace_return_type res;
     {
       const std::lock_guard<std::mutex> lock(lock_);
-      res = peers_.emplace(peer_id, mgr);
+      res = peers_.emplace(peer_id, std::move(mgr));
     }
     if (res.second)
-      return std::move(mgr);
+      return res.first->second;
     else
       return make_error(sec::runtime_error, "peer_id already exists");
   }

--- a/libcaf_net/caf/net/backend/tcp.hpp
+++ b/libcaf_net/caf/net/backend/tcp.hpp
@@ -21,33 +21,35 @@
 #include <map>
 
 #include "caf/detail/net_export.hpp"
-#include "caf/net/endpoint_manager.hpp"
+#include "caf/net/basp/application.hpp"
 #include "caf/net/fwd.hpp"
+#include "caf/net/make_endpoint_manager.hpp"
+#include "caf/net/middleman.hpp"
 #include "caf/net/middleman_backend.hpp"
-#include "caf/net/stream_socket.hpp"
+#include "caf/net/multiplexer.hpp"
+#include "caf/net/stream_transport.hpp"
+#include "caf/net/tcp_stream_socket.hpp"
 #include "caf/node_id.hpp"
 
 namespace caf::net::backend {
 
-/// Minimal backend for unit testing.
+/// Minimal backend for tcp communication.
 /// @warning this backend is *not* thread safe.
-class CAF_NET_EXPORT test : public middleman_backend {
+class CAF_NET_EXPORT tcp : public middleman_backend {
 public:
-  // -- member types -----------------------------------------------------------
-
-  using peer_entry = std::pair<stream_socket, endpoint_manager_ptr>;
-
   // -- constructors, destructors, and assignment operators --------------------
 
-  test(middleman& mm);
+  tcp(middleman& mm);
 
-  ~test() override;
+  ~tcp() override;
 
   // -- interface functions ----------------------------------------------------
 
   error init() override;
 
   void stop() override;
+
+  endpoint_manager_ptr connect(const uri& locator);
 
   endpoint_manager_ptr peer(const node_id& id) override;
 
@@ -59,27 +61,64 @@ public:
 
   void set_last_hop(node_id*) override;
 
+  void publish();
+
   // -- properties -------------------------------------------------------------
 
-  stream_socket socket(const node_id& peer_id) {
-    return get_peer(peer_id).first;
+  tcp_stream_socket socket(const node_id& peer_id) {
+    return socket_cast<tcp_stream_socket>(peers_[peer_id]->handle());
   }
 
   uint16_t port() const noexcept override {
-    return 0;
+    return listening_port_;
   }
 
-  peer_entry& emplace(const node_id& peer_id, stream_socket first,
-                      stream_socket second);
-
 private:
-  peer_entry& get_peer(const node_id& id);
+  class basp_application_factory {
+  public:
+    using application_type = basp::application;
+
+    basp_application_factory(proxy_registry& proxies);
+    ~basp_application_factory();
+
+    template <class Parent>
+    error init(Parent&) {
+      return none;
+    }
+
+    application_type make() const {
+      return application_type{proxies_};
+    }
+
+  private:
+    proxy_registry& proxies_;
+  };
+
+  template <class Handle>
+  endpoint_manager_ptr& emplace(const node_id& peer_id, Handle socket_handle) {
+    using transport_type = stream_transport<basp::application>;
+    nonblocking(socket_handle, true);
+    auto mpx = mm_.mpx();
+    basp::application app{proxies_};
+    auto mgr = make_endpoint_manager(
+      mpx, mm_.system(), transport_type{socket_handle, std::move(app)});
+    if (auto err = mgr->init()) {
+      CAF_LOG_ERROR("mgr->init() failed: " << err);
+      CAF_RAISE_ERROR("mgr->init() failed");
+    }
+    mpx->register_reading(mgr);
+    return peers_[peer_id];
+  }
+
+  endpoint_manager_ptr get_peer(const node_id& id);
 
   middleman& mm_;
 
-  std::map<node_id, peer_entry> peers_;
+  std::map<node_id, endpoint_manager_ptr> peers_;
 
   proxy_registry proxies_;
+
+  uint16_t listening_port_;
 };
 
 } // namespace caf::net::backend

--- a/libcaf_net/caf/net/backend/test.hpp
+++ b/libcaf_net/caf/net/backend/test.hpp
@@ -51,6 +51,8 @@ public:
 
   endpoint_manager_ptr peer(const node_id& id) override;
 
+  endpoint_manager_ptr connect(const uri& locator) override;
+
   void publish(actor handle, const uri& locator) override;
 
   void resolve(const uri& locator, const actor& listener) override;

--- a/libcaf_net/caf/net/backend/test.hpp
+++ b/libcaf_net/caf/net/backend/test.hpp
@@ -53,7 +53,7 @@ public:
 
   endpoint_manager_ptr connect(const uri& locator) override;
 
-  void publish(actor handle, const uri& locator) override;
+  void publish(actor handle, string_view path) override;
 
   void resolve(const uri& locator, const actor& listener) override;
 

--- a/libcaf_net/caf/net/backend/test.hpp
+++ b/libcaf_net/caf/net/backend/test.hpp
@@ -51,7 +51,7 @@ public:
 
   endpoint_manager_ptr peer(const node_id& id) override;
 
-  endpoint_manager_ptr connect(const uri& locator) override;
+  expected<endpoint_manager_ptr> connect(const uri& locator) override;
 
   void resolve(const uri& locator, const actor& listener) override;
 

--- a/libcaf_net/caf/net/backend/test.hpp
+++ b/libcaf_net/caf/net/backend/test.hpp
@@ -53,8 +53,6 @@ public:
 
   endpoint_manager_ptr connect(const uri& locator) override;
 
-  void publish(actor handle, string_view path) override;
-
   void resolve(const uri& locator, const actor& listener) override;
 
   strong_actor_ptr make_proxy(node_id nid, actor_id aid) override;

--- a/libcaf_net/caf/net/backend/test.hpp
+++ b/libcaf_net/caf/net/backend/test.hpp
@@ -51,7 +51,7 @@ public:
 
   endpoint_manager_ptr peer(const node_id& id) override;
 
-  expected<endpoint_manager_ptr> connect(const uri& locator) override;
+  expected<endpoint_manager_ptr> get_or_connect(const uri& locator) override;
 
   void resolve(const uri& locator, const actor& listener) override;
 
@@ -65,9 +65,7 @@ public:
     return get_peer(peer_id).first;
   }
 
-  uint16_t port() const noexcept override {
-    return 0;
-  }
+  uint16_t port() const noexcept override;
 
   peer_entry& emplace(const node_id& peer_id, stream_socket first,
                       stream_socket second);

--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -31,6 +31,7 @@
 #include "caf/byte.hpp"
 #include "caf/callback.hpp"
 #include "caf/defaults.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/detail/worker_hub.hpp"
 #include "caf/error.hpp"
 #include "caf/fwd.hpp"
@@ -52,7 +53,7 @@
 namespace caf::net::basp {
 
 /// An implementation of BASP as an application layer protocol.
-class application {
+class CAF_NET_EXPORT application {
 public:
   // -- member types -----------------------------------------------------------
 

--- a/libcaf_net/caf/net/basp/application_factory.hpp
+++ b/libcaf_net/caf/net/basp/application_factory.hpp
@@ -1,0 +1,48 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "caf/error.hpp"
+#include "caf/net/basp/application.hpp"
+#include "caf/proxy_registry.hpp"
+
+namespace caf::net::basp {
+
+class CAF_NET_EXPORT application_factory {
+public:
+  using application_type = basp::application;
+
+  application_factory(proxy_registry& proxies) : proxies_(proxies) {
+    // nop
+  }
+
+  template <class Parent>
+  error init(Parent&) {
+    return none;
+  }
+
+  application_type make() const {
+    return application_type{proxies_};
+  }
+
+private:
+  proxy_registry& proxies_;
+};
+
+} // namespace caf::net::basp

--- a/libcaf_net/caf/net/basp/application_factory.hpp
+++ b/libcaf_net/caf/net/basp/application_factory.hpp
@@ -18,12 +18,15 @@
 
 #pragma once
 
+#include "caf/detail/net_export.hpp"
 #include "caf/error.hpp"
 #include "caf/net/basp/application.hpp"
 #include "caf/proxy_registry.hpp"
 
 namespace caf::net::basp {
 
+/// Factory for basp::application.
+/// @relates doorman
 class CAF_NET_EXPORT application_factory {
 public:
   using application_type = basp::application;

--- a/libcaf_net/caf/net/basp/header.hpp
+++ b/libcaf_net/caf/net/basp/header.hpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 
 #include "caf/detail/comparable.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"
 #include "caf/meta/hex_formatted.hpp"
 #include "caf/meta/type_name.hpp"
@@ -33,7 +34,7 @@ namespace caf::net::basp {
 /// @addtogroup BASP
 
 /// The header of a Binary Actor System Protocol (BASP) message.
-struct header : detail::comparable<header> {
+struct CAF_NET_EXPORT header : detail::comparable<header> {
   // -- constructors, destructors, and assignment operators --------------------
 
   constexpr header() noexcept
@@ -74,11 +75,11 @@ struct header : detail::comparable<header> {
 
 /// Serializes a header to a byte representation.
 /// @relates header
-std::array<byte, header_size> to_bytes(header x);
+CAF_NET_EXPORT std::array<byte, header_size> to_bytes(header x);
 
 /// Serializes a header to a byte representation.
 /// @relates header
-void to_bytes(header x, byte_buffer& buf);
+CAF_NET_EXPORT void to_bytes(header x, byte_buffer& buf);
 
 /// @relates header
 template <class Inspector>

--- a/libcaf_net/caf/net/basp/worker.hpp
+++ b/libcaf_net/caf/net/basp/worker.hpp
@@ -24,6 +24,7 @@
 #include "caf/byte_buffer.hpp"
 #include "caf/config.hpp"
 #include "caf/detail/abstract_worker.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/detail/worker_hub.hpp"
 #include "caf/fwd.hpp"
 #include "caf/net/basp/header.hpp"
@@ -36,8 +37,8 @@
 namespace caf::net::basp {
 
 /// Deserializes payloads for BASP messages asynchronously.
-class worker : public detail::abstract_worker,
-               public remote_message_handler<worker> {
+class CAF_NET_EXPORT worker : public detail::abstract_worker,
+                              public remote_message_handler<worker> {
 public:
   // -- friends ----------------------------------------------------------------
 

--- a/libcaf_net/caf/net/defaults.hpp
+++ b/libcaf_net/caf/net/defaults.hpp
@@ -21,17 +21,19 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "caf/detail/net_export.hpp"
+
 // -- hard-coded default values for various CAF options ------------------------
 
 namespace caf::defaults::middleman {
 
 /// Maximum number of cached buffers for sending payloads.
-extern const size_t max_payload_buffers;
+CAF_NET_EXPORT extern const size_t max_payload_buffers;
 
 /// Maximum number of cached buffers for sending headers.
-extern const size_t max_header_buffers;
+CAF_NET_EXPORT extern const size_t max_header_buffers;
 
 /// Port to listen on for tcp.
-extern const uint16_t tcp_port;
+CAF_NET_EXPORT extern const uint16_t tcp_port;
 
 } // namespace caf::defaults::middleman

--- a/libcaf_net/caf/net/defaults.hpp
+++ b/libcaf_net/caf/net/defaults.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 // -- hard-coded default values for various CAF options ------------------------
 
@@ -29,5 +30,8 @@ extern const size_t max_payload_buffers;
 
 /// Maximum number of cached buffers for sending headers.
 extern const size_t max_header_buffers;
+
+/// Port to listen on for tcp.
+extern const uint16_t tcp_port;
 
 } // namespace caf::defaults::middleman

--- a/libcaf_net/caf/net/endpoint_manager_queue.hpp
+++ b/libcaf_net/caf/net/endpoint_manager_queue.hpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "caf/actor.hpp"
+#include "caf/detail/net_export.hpp"
 #include "caf/detail/serialized_size.hpp"
 #include "caf/fwd.hpp"
 #include "caf/intrusive/drr_queue.hpp"
@@ -33,7 +34,7 @@
 
 namespace caf::net {
 
-class endpoint_manager_queue {
+class CAF_NET_EXPORT endpoint_manager_queue {
 public:
   enum class element_type { event, message };
 

--- a/libcaf_net/caf/net/middleman.hpp
+++ b/libcaf_net/caf/net/middleman.hpp
@@ -92,11 +92,11 @@ public:
     // TODO: Use function view?
     scoped_actor self{sys_};
     resolve(locator, self);
-    Handle actor_ptr;
-    error err = none;
+    Handle handle;
+    error err;
     self->receive(
-      [&actor_ptr](strong_actor_ptr& ptr, const std::set<std::string>&) {
-        actor_ptr = actor_cast<Handle>(std::move(ptr));
+      [&handle](strong_actor_ptr& ptr, const std::set<std::string>&) {
+        handle = actor_cast<Handle>(std::move(ptr));
       },
       [&err](const error& e) { err = e; },
       // TODO: how long should the middleman wait before erroring out?
@@ -107,7 +107,9 @@ public:
         });
     if (err)
       return err;
-    return actor_ptr;
+    if (handle)
+      return handle;
+    return make_error(sec::runtime_error, "cast to handle-type failed");
   }
 
   // -- properties -------------------------------------------------------------

--- a/libcaf_net/caf/net/middleman.hpp
+++ b/libcaf_net/caf/net/middleman.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <set>
 #include <string>
 #include <thread>
@@ -87,11 +88,9 @@ public:
   /// Resolves a path to a remote actor.
   void resolve(const uri& locator, const actor& listener);
 
-  template <class Handle = actor, class Rep, class Period>
-  expected<Handle>
-  remote_actor(const uri& locator,
-               std::chrono::duration<Rep, Period> timeout_duration
-               = std::chrono::seconds(5)) {
+  template <class Handle = actor, class Duration = std::chrono::seconds>
+  expected<Handle> remote_actor(const uri& locator, Duration timeout_duration
+                                                    = std::chrono::seconds(5)) {
     scoped_actor self{sys_};
     resolve(locator, self);
     Handle handle;

--- a/libcaf_net/caf/net/middleman.hpp
+++ b/libcaf_net/caf/net/middleman.hpp
@@ -89,7 +89,6 @@ public:
 
   template <class Handle = actor>
   expected<Handle> remote_actor(const uri& locator) {
-    // TODO: Use function view?
     scoped_actor self{sys_};
     resolve(locator, self);
     Handle handle;

--- a/libcaf_net/caf/net/middleman.hpp
+++ b/libcaf_net/caf/net/middleman.hpp
@@ -76,6 +76,8 @@ public:
 
   // -- remoting ---------------------------------------------------------------
 
+  expected<endpoint_manager_ptr> connect(const uri& locator);
+
   // Publishes an actor.
   template <class Handle = actor>
   error publish(Handle whom, const uri& locator) {
@@ -123,6 +125,8 @@ public:
   }
 
   middleman_backend* backend(string_view scheme) const noexcept;
+
+  expected<uint16_t> port(string_view scheme) const;
 
 private:
   // -- constructors, destructors, and assignment operators --------------------

--- a/libcaf_net/caf/net/middleman_backend.hpp
+++ b/libcaf_net/caf/net/middleman_backend.hpp
@@ -49,9 +49,6 @@ public:
   /// Establishes a connection to a remote node.
   virtual endpoint_manager_ptr connect(const uri& locator) = 0;
 
-  /// Publishes an actor.
-  virtual void publish(actor handle, string_view path) = 0;
-
   /// Resolves a path to a remote actor.
   virtual void resolve(const uri& locator, const actor& listener) = 0;
 

--- a/libcaf_net/caf/net/middleman_backend.hpp
+++ b/libcaf_net/caf/net/middleman_backend.hpp
@@ -47,7 +47,7 @@ public:
   virtual endpoint_manager_ptr peer(const node_id& id) = 0;
 
   /// Establishes a connection to a remote node.
-  virtual endpoint_manager_ptr connect(const uri& locator) = 0;
+  virtual expected<endpoint_manager_ptr> connect(const uri& locator) = 0;
 
   /// Resolves a path to a remote actor.
   virtual void resolve(const uri& locator, const actor& listener) = 0;

--- a/libcaf_net/caf/net/middleman_backend.hpp
+++ b/libcaf_net/caf/net/middleman_backend.hpp
@@ -46,6 +46,9 @@ public:
   /// @returns The endpoint manager for `peer` on success, `nullptr` otherwise.
   virtual endpoint_manager_ptr peer(const node_id& id) = 0;
 
+  /// Publishes an actor.
+  virtual void publish(actor handle, const uri& locator) = 0;
+
   /// Resolves a path to a remote actor.
   virtual void resolve(const uri& locator, const actor& listener) = 0;
 
@@ -56,6 +59,8 @@ public:
   const std::string& id() const noexcept {
     return id_;
   }
+
+  virtual uint16_t port() const = 0;
 
 private:
   /// Stores the technology-specific identifier.

--- a/libcaf_net/caf/net/middleman_backend.hpp
+++ b/libcaf_net/caf/net/middleman_backend.hpp
@@ -46,6 +46,9 @@ public:
   /// @returns The endpoint manager for `peer` on success, `nullptr` otherwise.
   virtual endpoint_manager_ptr peer(const node_id& id) = 0;
 
+  /// Establishes a connection to a remote node.
+  virtual endpoint_manager_ptr connect(const uri& locator) = 0;
+
   /// Publishes an actor.
   virtual void publish(actor handle, const uri& locator) = 0;
 

--- a/libcaf_net/caf/net/middleman_backend.hpp
+++ b/libcaf_net/caf/net/middleman_backend.hpp
@@ -50,7 +50,7 @@ public:
   virtual endpoint_manager_ptr connect(const uri& locator) = 0;
 
   /// Publishes an actor.
-  virtual void publish(actor handle, const uri& locator) = 0;
+  virtual void publish(actor handle, string_view path) = 0;
 
   /// Resolves a path to a remote actor.
   virtual void resolve(const uri& locator, const actor& listener) = 0;

--- a/libcaf_net/caf/net/middleman_backend.hpp
+++ b/libcaf_net/caf/net/middleman_backend.hpp
@@ -47,7 +47,7 @@ public:
   virtual endpoint_manager_ptr peer(const node_id& id) = 0;
 
   /// Establishes a connection to a remote node.
-  virtual expected<endpoint_manager_ptr> connect(const uri& locator) = 0;
+  virtual expected<endpoint_manager_ptr> get_or_connect(const uri& locator) = 0;
 
   /// Resolves a path to a remote actor.
   virtual void resolve(const uri& locator, const actor& listener) = 0;

--- a/libcaf_net/caf/net/multiplexer.hpp
+++ b/libcaf_net/caf/net/multiplexer.hpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <thread>
 
+#include "caf/detail/net_export.hpp"
 #include "caf/net/fwd.hpp"
 #include "caf/net/operation.hpp"
 #include "caf/net/pipe_socket.hpp"
@@ -37,7 +38,8 @@ struct pollfd;
 namespace caf::net {
 
 /// Multiplexes any number of ::socket_manager objects with a ::socket.
-class multiplexer : public std::enable_shared_from_this<multiplexer> {
+class CAF_NET_EXPORT multiplexer
+  : public std::enable_shared_from_this<multiplexer> {
 public:
   // -- member types -----------------------------------------------------------
 

--- a/libcaf_net/caf/net/socket_manager.hpp
+++ b/libcaf_net/caf/net/socket_manager.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "caf/detail/net_export.hpp"
 #include "caf/error.hpp"
 #include "caf/fwd.hpp"
 #include "caf/net/fwd.hpp"
@@ -28,7 +29,7 @@
 namespace caf::net {
 
 /// Manages the lifetime of a single socket and handles any I/O events on it.
-class socket_manager : public ref_counted {
+class CAF_NET_EXPORT socket_manager : public ref_counted {
 public:
   // -- constructors, destructors, and assignment operators --------------------
 

--- a/libcaf_net/src/basp/application.cpp
+++ b/libcaf_net/src/basp/application.cpp
@@ -29,7 +29,6 @@
 #include "caf/detail/network_order.hpp"
 #include "caf/detail/parse.hpp"
 #include "caf/error.hpp"
-#include "caf/expected.hpp"
 #include "caf/logger.hpp"
 #include "caf/net/basp/constants.hpp"
 #include "caf/net/basp/ec.hpp"

--- a/libcaf_net/src/defaults.cpp
+++ b/libcaf_net/src/defaults.cpp
@@ -24,4 +24,6 @@ const size_t max_payload_buffers = 100;
 
 const size_t max_header_buffers = 10;
 
+const uint16_t tcp_port = 0;
+
 } // namespace caf::defaults::middleman

--- a/libcaf_net/src/net/backend/tcp.cpp
+++ b/libcaf_net/src/net/backend/tcp.cpp
@@ -22,6 +22,7 @@
 
 #include "caf/net/actor_proxy_impl.hpp"
 #include "caf/net/basp/application.hpp"
+#include "caf/net/basp/application_factory.hpp"
 #include "caf/net/basp/ec.hpp"
 #include "caf/net/doorman.hpp"
 #include "caf/net/ip.hpp"
@@ -65,9 +66,9 @@ error tcp::init() {
   if (!doorman_uri)
     return doorman_uri.error();
   auto& mpx = mm_.mpx();
-  auto mgr = make_endpoint_manager(mpx, mm_.system(),
-                                   doorman{acc_guard.release(),
-                                           basp_application_factory{proxies_}});
+  auto mgr = make_endpoint_manager(
+    mpx, mm_.system(),
+    doorman{acc_guard.release(), basp::application_factory{proxies_}});
   if (auto err = mgr->init()) {
     CAF_LOG_ERROR("mgr->init() failed: " << err);
     return err;
@@ -136,11 +137,6 @@ endpoint_manager_ptr tcp::get_peer(const node_id& id) {
   if (i != peers_.end())
     return i->second;
   return nullptr;
-}
-
-tcp::basp_application_factory::basp_application_factory(proxy_registry& proxies)
-  : proxies_(proxies) {
-  // nop
 }
 
 } // namespace caf::net::backend

--- a/libcaf_net/src/net/backend/tcp.cpp
+++ b/libcaf_net/src/net/backend/tcp.cpp
@@ -65,9 +65,9 @@ error tcp::init() {
   if (!doorman_uri)
     return doorman_uri.error();
   auto& mpx = mm_.mpx();
-  auto mgr = make_endpoint_manager(
-    mpx, mm_.system(),
-    doorman{acc_guard.release(), tcp::basp_application_factory{proxies_}});
+  auto mgr = make_endpoint_manager(mpx, mm_.system(),
+                                   doorman{acc_guard.release(),
+                                           basp_application_factory{proxies_}});
   if (auto err = mgr->init()) {
     CAF_LOG_ERROR("mgr->init() failed: " << err);
     return err;

--- a/libcaf_net/src/net/backend/tcp.cpp
+++ b/libcaf_net/src/net/backend/tcp.cpp
@@ -27,7 +27,6 @@
 #include "caf/net/ip.hpp"
 #include "caf/net/make_endpoint_manager.hpp"
 #include "caf/net/middleman.hpp"
-#include "caf/net/multiplexer.hpp"
 #include "caf/net/socket_guard.hpp"
 #include "caf/net/stream_transport.hpp"
 #include "caf/net/tcp_accept_socket.hpp"
@@ -47,7 +46,7 @@ tcp::~tcp() {
 
 error tcp::init() {
   uint16_t conf_port = get_or<uint16_t>(
-    mm_.system().config(), "middleman.tcp_port", defaults::middleman::tcp_port);
+    mm_.system().config(), "middleman.tcp-port", defaults::middleman::tcp_port);
   ip_endpoint ep;
   auto local_address = std::string("[::]:") + std::to_string(conf_port);
   if (auto err = detail::parse(local_address, ep))
@@ -61,6 +60,7 @@ error tcp::init() {
   if (!port)
     return port.error();
   listening_port_ = *port;
+  CAF_LOG_INFO("doorman spawned on " << CAF_ARG(*port));
   auto doorman_uri = make_uri("tcp://doorman");
   if (!doorman_uri)
     return doorman_uri.error();

--- a/libcaf_net/src/net/backend/tcp.cpp
+++ b/libcaf_net/src/net/backend/tcp.cpp
@@ -109,20 +109,10 @@ endpoint_manager_ptr tcp::peer(const node_id& id) {
 }
 
 void tcp::resolve(const uri& locator, const actor& listener) {
-  if (auto id = locator.authority_only()) {
-    auto p = peer(make_node_id(*id));
-    if (p == nullptr) {
-      CAF_LOG_INFO("connecting to " << CAF_ARG(locator));
-      auto res = get_or_connect(locator);
-      if (!res)
-        anon_send(listener, error(sec::cannot_connect_to_node));
-      else
-        p = *res;
-    }
-    p->resolve(locator, listener);
-  } else {
-    anon_send(listener, error(basp::ec::invalid_locator));
-  }
+  if (auto p = get_or_connect(locator))
+    (*p)->resolve(locator, listener);
+  else
+    anon_send(listener, p.error());
 }
 
 strong_actor_ptr tcp::make_proxy(node_id nid, actor_id aid) {

--- a/libcaf_net/src/net/backend/tcp.cpp
+++ b/libcaf_net/src/net/backend/tcp.cpp
@@ -101,8 +101,7 @@ endpoint_manager_ptr tcp::peer(const node_id& id) {
   return get_peer(id);
 }
 
-void tcp::publish(actor handle, const uri& locator) {
-  auto path = locator.path();
+void tcp::publish(actor handle, string_view path) {
   mm_.system().registry().put(std::string(path.begin(), path.end()), handle);
 }
 

--- a/libcaf_net/src/net/backend/tcp.cpp
+++ b/libcaf_net/src/net/backend/tcp.cpp
@@ -64,7 +64,6 @@ error tcp::init() {
   auto doorman_uri = make_uri("tcp://doorman");
   if (!doorman_uri)
     return doorman_uri.error();
-  ;
   auto& mpx = mm_.mpx();
   auto mgr = make_endpoint_manager(
     mpx, mm_.system(),
@@ -73,7 +72,6 @@ error tcp::init() {
     CAF_LOG_ERROR("mgr->init() failed: " << err);
     return err;
   }
-  mpx->register_reading(mgr);
   return none;
 }
 
@@ -133,6 +131,11 @@ endpoint_manager_ptr tcp::get_peer(const node_id& id) {
   if (i != peers_.end())
     return i->second;
   return nullptr;
+}
+
+tcp::basp_application_factory::basp_application_factory(proxy_registry& proxies)
+  : proxies_(proxies) {
+  // nop
 }
 
 } // namespace caf::net::backend

--- a/libcaf_net/src/net/backend/tcp.cpp
+++ b/libcaf_net/src/net/backend/tcp.cpp
@@ -101,10 +101,6 @@ endpoint_manager_ptr tcp::peer(const node_id& id) {
   return get_peer(id);
 }
 
-void tcp::publish(actor handle, string_view path) {
-  mm_.system().registry().put(std::string(path.begin(), path.end()), handle);
-}
-
 void tcp::resolve(const uri& locator, const actor& listener) {
   auto id = locator.authority_only();
   if (id)

--- a/libcaf_net/src/net/backend/test.cpp
+++ b/libcaf_net/src/net/backend/test.cpp
@@ -27,6 +27,7 @@
 #include "caf/net/multiplexer.hpp"
 #include "caf/net/stream_transport.hpp"
 #include "caf/raise_error.hpp"
+#include "caf/sec.hpp"
 #include "caf/send.hpp"
 
 namespace caf::net::backend {
@@ -54,8 +55,9 @@ endpoint_manager_ptr test::peer(const node_id& id) {
   return get_peer(id).second;
 }
 
-endpoint_manager_ptr test::connect(const uri&) {
-  return nullptr;
+expected<endpoint_manager_ptr> test::connect(const uri&) {
+  return make_error(sec::runtime_error,
+                    "function not implemented in test_backend");
 }
 
 void test::resolve(const uri& locator, const actor& listener) {

--- a/libcaf_net/src/net/backend/test.cpp
+++ b/libcaf_net/src/net/backend/test.cpp
@@ -55,9 +55,11 @@ endpoint_manager_ptr test::peer(const node_id& id) {
   return get_peer(id).second;
 }
 
-expected<endpoint_manager_ptr> test::connect(const uri&) {
+expected<endpoint_manager_ptr> test::get_or_connect(const uri& locator) {
+  if (auto ptr = peer(make_node_id(*locator.authority_only())))
+    return ptr;
   return make_error(sec::runtime_error,
-                    "function not implemented in test_backend");
+                    "connecting not implemented in test backend");
 }
 
 void test::resolve(const uri& locator, const actor& listener) {
@@ -78,6 +80,10 @@ strong_actor_ptr test::make_proxy(node_id nid, actor_id aid) {
 
 void test::set_last_hop(node_id*) {
   // nop
+}
+
+uint16_t test::port() const noexcept {
+  return 0;
 }
 
 test::peer_entry& test::emplace(const node_id& peer_id, stream_socket first,

--- a/libcaf_net/src/net/backend/test.cpp
+++ b/libcaf_net/src/net/backend/test.cpp
@@ -58,7 +58,7 @@ endpoint_manager_ptr test::connect(const uri&) {
   return nullptr;
 }
 
-void test::publish(actor, const uri&) {
+void test::publish(actor, string_view) {
   // nop
 }
 

--- a/libcaf_net/src/net/backend/test.cpp
+++ b/libcaf_net/src/net/backend/test.cpp
@@ -58,10 +58,6 @@ endpoint_manager_ptr test::connect(const uri&) {
   return nullptr;
 }
 
-void test::publish(actor, string_view) {
-  // nop
-}
-
 void test::resolve(const uri& locator, const actor& listener) {
   auto id = locator.authority_only();
   if (id)

--- a/libcaf_net/src/net/backend/test.cpp
+++ b/libcaf_net/src/net/backend/test.cpp
@@ -54,6 +54,10 @@ endpoint_manager_ptr test::peer(const node_id& id) {
   return get_peer(id).second;
 }
 
+endpoint_manager_ptr test::connect(const uri&) {
+  return nullptr;
+}
+
 void test::publish(actor, const uri&) {
   // nop
 }

--- a/libcaf_net/src/net/middleman.cpp
+++ b/libcaf_net/src/net/middleman.cpp
@@ -86,7 +86,6 @@ void middleman::init(actor_system_config& cfg) {
       CAF_LOG_ERROR("failed to initialize backend: " << err);
       CAF_RAISE_ERROR("failed to initialize backend");
     }
-  std::cout << "init" << std::endl;
 }
 
 middleman::module::id_t middleman::id() const {

--- a/libcaf_net/src/net/middleman.cpp
+++ b/libcaf_net/src/net/middleman.cpp
@@ -101,7 +101,7 @@ expected<endpoint_manager_ptr> middleman::connect(const uri& locator) {
   if (auto ret = ptr->connect(locator))
     return ret;
   else
-    return sec::cannot_connect_to_node;
+    return basp::ec::invalid_scheme;
 }
 
 void middleman::resolve(const uri& locator, const actor& listener) {
@@ -127,7 +127,7 @@ expected<uint16_t> middleman::port(string_view scheme) const {
   if (ptr != nullptr)
     return ptr->port();
   else
-    return sec::invalid_protocol_family;
+    return basp::ec::invalid_scheme;
 }
 
 } // namespace caf::net

--- a/libcaf_net/src/net/middleman.cpp
+++ b/libcaf_net/src/net/middleman.cpp
@@ -97,9 +97,8 @@ void* middleman::subtype_ptr() {
 }
 
 expected<endpoint_manager_ptr> middleman::connect(const uri& locator) {
-  auto ptr = backend(locator.scheme());
-  if (auto ret = ptr->connect(locator))
-    return ret;
+  if (auto ptr = backend(locator.scheme()))
+    return ptr->get_or_connect(locator);
   else
     return basp::ec::invalid_scheme;
 }
@@ -123,8 +122,7 @@ middleman_backend* middleman::backend(string_view scheme) const noexcept {
 }
 
 expected<uint16_t> middleman::port(string_view scheme) const {
-  auto ptr = backend(scheme);
-  if (ptr != nullptr)
+  if (auto ptr = backend(scheme))
     return ptr->port();
   else
     return basp::ec::invalid_scheme;

--- a/libcaf_net/test/net/backend/tcp.cpp
+++ b/libcaf_net/test/net/backend/tcp.cpp
@@ -137,7 +137,7 @@ CAF_TEST(doorman accept) {
   run();
   CAF_CHECK(sock);
   auto guard = make_socket_guard(*sock);
-  CAF_REQUIRE_EQUAL(earth.mpx->num_socket_managers(), 3);
+  CAF_CHECK_EQUAL(earth.mpx->num_socket_managers(), 3);
 }
 
 CAF_TEST(connect) {
@@ -153,7 +153,7 @@ CAF_TEST(connect) {
   auto sock = unbox(accept(acc_guard.socket()));
   auto sock_guard = make_socket_guard(sock);
   handle_io_event();
-  CAF_REQUIRE_EQUAL(earth.mpx->num_socket_managers(), 3);
+  CAF_CHECK_EQUAL(earth.mpx->num_socket_managers(), 3);
 }
 
 CAF_TEST(publish) {
@@ -162,7 +162,7 @@ CAF_TEST(publish) {
   CAF_MESSAGE("publishing actor " << CAF_ARG(path));
   earth.mm.publish(dummy, path);
   CAF_MESSAGE("check registry for " << CAF_ARG(path));
-  CAF_CHECK(earth.sys.registry().get(path) != nullptr);
+  CAF_CHECK_NOT_EQUAL(earth.sys.registry().get(path), nullptr);
 }
 
 /*

--- a/libcaf_net/test/net/backend/tcp.cpp
+++ b/libcaf_net/test/net/backend/tcp.cpp
@@ -165,20 +165,20 @@ CAF_TEST(publish) {
   CAF_CHECK_NOT_EQUAL(earth.sys.registry().get(path), nullptr);
 }
 
-/*
-// TODO: `middleman.this-node` cannot be set according to randomly bound port of
-         the node. Thus, the test segfaults  when creating the new actor with
-         `nullptr` for the `endpoint_manager`...
-
 CAF_TEST(remote_actor) {
   using std::chrono::milliseconds;
   using std::chrono::seconds;
+  auto sockets = unbox(make_stream_socket_pair());
+  auto earth_be = reinterpret_cast<net::backend::tcp*>(earth.mm.backend("tcp"));
+  earth_be->emplace(mars.id(), sockets.first);
+  auto mars_be = reinterpret_cast<net::backend::tcp*>(mars.mm.backend("tcp"));
+  mars_be->emplace(earth.id(), sockets.second);
+  handle_io_event();
+  CAF_CHECK_EQUAL(earth.mpx->num_socket_managers(), 3);
+  CAF_CHECK_EQUAL(mars.mpx->num_socket_managers(), 3);
   auto dummy = earth.sys.spawn(dummy_actor);
-  auto name = "dummy"s;
-  earth.mm.publish(dummy, name);
-  auto port = unbox(earth.mm.port("tcp"));
-  auto ep_str = "tcp://localhost:"s + std::to_string(port);
-  auto locator = unbox(make_uri(ep_str + "/name/"s + name));
+  earth.mm.publish(dummy, "dummy"s);
+  auto locator = unbox(make_uri("tcp://earth/name/dummy"s));
   CAF_MESSAGE("resolve " << CAF_ARG(locator));
   bool running = true;
   auto f = [&]() {
@@ -195,6 +195,6 @@ CAF_TEST(remote_actor) {
   running = false;
   t.join();
   set_thread_id();
-}*/
+}
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_net/test/net/backend/tcp.cpp
+++ b/libcaf_net/test/net/backend/tcp.cpp
@@ -1,0 +1,94 @@
+/******************************************************************************
+ *                       ____    _    _____                                   *
+ *                      / ___|  / \  |  ___|    C++                           *
+ *                     | |     / _ \ | |_       Actor                         *
+ *                     | |___ / ___ \|  _|      Framework                     *
+ *                      \____/_/   \_|_|                                      *
+ *                                                                            *
+ * Copyright 2011-2019 Dominik Charousset                                     *
+ *                                                                            *
+ * Distributed under the terms and conditions of the BSD 3-Clause License or  *
+ * (at your option) under the terms and conditions of the Boost Software      *
+ * License 1.0. See accompanying files LICENSE and LICENSE_ALTERNATIVE.       *
+ *                                                                            *
+ * If you did not receive a copy of the license files, see                    *
+ * http://opensource.org/licenses/BSD-3-Clause and                            *
+ * http://www.boost.org/LICENSE_1_0.txt.                                      *
+ ******************************************************************************/
+
+#define CAF_SUITE net.backend.tcp
+
+#include "caf/net/backend/tcp.hpp"
+
+#include "caf/net/test/host_fixture.hpp"
+#include "caf/test/dsl.hpp"
+
+#include "caf/ip_endpoint.hpp"
+#include "caf/net/middleman.hpp"
+#include "caf/net/socket_guard.hpp"
+
+using namespace caf;
+using namespace caf::net;
+
+namespace {
+
+struct config : actor_system_config {
+  config() {
+    put(content, "middleman.this-node", unbox(make_uri("tcp://earth")));
+    load<middleman, backend::tcp>();
+  }
+};
+
+struct fixture : test_coordinator_fixture<config>, host_fixture {
+  using byte_buffer_ptr = std::shared_ptr<byte_buffer>;
+
+  fixture() : mm{sys.network_manager()}, mpx{mm.mpx()} {
+    mpx->set_thread_id();
+    handle_io_events();
+  }
+
+  bool handle_io_event() override {
+    return mpx->poll_once(false);
+  }
+
+  net::middleman& mm;
+  const multiplexer_ptr& mpx;
+};
+
+} // namespace
+
+CAF_TEST_FIXTURE_SCOPE(tcp_backend_tests, fixture)
+
+CAF_TEST(doorman accept) {
+  CAF_CHECK_EQUAL(mpx->num_socket_managers(), 2);
+  auto backend = mm.backend("tcp");
+  CAF_CHECK(backend);
+  auto port = backend->port();
+  CAF_MESSAGE("trying to connect to system with " << CAF_ARG(port));
+  ip_endpoint ep;
+  auto ep_str = std::string("[::1]:") + std::to_string(port);
+  if (auto err = detail::parse(ep_str, ep))
+    CAF_FAIL("could not parse " << CAF_ARG(ep_str) << " " << CAF_ARG(err));
+  auto sock = make_connected_tcp_stream_socket(ep);
+  if (!sock)
+    CAF_FAIL("could not connect");
+  auto guard = make_socket_guard(*sock);
+  handle_io_event();
+  CAF_CHECK_EQUAL(mpx->num_socket_managers(), 3);
+}
+
+CAF_TEST(connect) {
+  ip_endpoint ep;
+  if (auto err = detail::parse("[::]:0", ep))
+    CAF_FAIL("could not parse endpoint" << err);
+  auto acceptor = make_tcp_accept_socket(ep);
+  CAF_CHECK(!acceptor)
+  auto acc_guard = make_socket_guard(*acceptor);
+  auto port = local_port(*acc_guard);
+  auto uri_str = std::string("tcp://localhost:") + std::to_string(port);
+  CAF_MESSAGE("connecting to " << CAF_ARG(uri_str));
+  auto ptr = mm.backend("tcp");
+  CAF_CHECK(mm->connect(make_uri(ep_string)));
+}
+
+CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_net/test/net/backend/tcp.cpp
+++ b/libcaf_net/test/net/backend/tcp.cpp
@@ -68,9 +68,7 @@ struct config : actor_system_config {
 
 class planet_driver {
 public:
-  virtual ~planet_driver() {
-    // nop
-  }
+  virtual ~planet_driver() = default;
 
   virtual bool handle_io_event() = 0;
 };
@@ -100,18 +98,14 @@ private:
 
 struct fixture : host_fixture, planet_driver {
   fixture() : earth(*this), mars(*this) {
-    run();
+    earth.run();
+    mars.run();
     CAF_REQUIRE_EQUAL(earth.mpx->num_socket_managers(), 2);
     CAF_REQUIRE_EQUAL(mars.mpx->num_socket_managers(), 2);
   }
 
   bool handle_io_event() override {
     return earth.mpx->poll_once(false) || mars.mpx->poll_once(false);
-  }
-
-  void set_thread_id() {
-    earth.mpx->set_thread_id();
-    mars.mpx->set_thread_id();
   }
 
   void run() {
@@ -134,9 +128,14 @@ CAF_TEST(doorman accept) {
   auth.port = backend->port();
   CAF_MESSAGE("trying to connect to earth at " << CAF_ARG(auth));
   auto sock = make_connected_tcp_stream_socket(auth);
-  run();
   CAF_CHECK(sock);
   auto guard = make_socket_guard(*sock);
+  int runs = 0;
+  while (earth.mpx->num_socket_managers() < 3) {
+    if (++runs >= 5)
+      CAF_FAIL("doorman did not create endpoint_manager");
+    run();
+  }
   CAF_CHECK_EQUAL(earth.mpx->num_socket_managers(), 3);
 }
 
@@ -158,21 +157,21 @@ CAF_TEST(connect) {
 
 CAF_TEST(publish) {
   auto dummy = earth.sys.spawn(dummy_actor);
-  auto path = "name/dummy"s;
+  auto path = "dummy"s;
   CAF_MESSAGE("publishing actor " << CAF_ARG(path));
   earth.mm.publish(dummy, path);
   CAF_MESSAGE("check registry for " << CAF_ARG(path));
   CAF_CHECK_NOT_EQUAL(earth.sys.registry().get(path), nullptr);
 }
 
-CAF_TEST(remote_actor) {
+CAF_TEST(resolve) {
   using std::chrono::milliseconds;
   using std::chrono::seconds;
   auto sockets = unbox(make_stream_socket_pair());
   auto earth_be = reinterpret_cast<net::backend::tcp*>(earth.mm.backend("tcp"));
-  earth_be->emplace(mars.id(), sockets.first);
+  CAF_CHECK(earth_be->emplace(mars.id(), sockets.first));
   auto mars_be = reinterpret_cast<net::backend::tcp*>(mars.mm.backend("tcp"));
-  mars_be->emplace(earth.id(), sockets.second);
+  CAF_CHECK(mars_be->emplace(earth.id(), sockets.second));
   handle_io_event();
   CAF_CHECK_EQUAL(earth.mpx->num_socket_managers(), 3);
   CAF_CHECK_EQUAL(mars.mpx->num_socket_managers(), 3);
@@ -180,21 +179,20 @@ CAF_TEST(remote_actor) {
   earth.mm.publish(dummy, "dummy"s);
   auto locator = unbox(make_uri("tcp://earth/name/dummy"s));
   CAF_MESSAGE("resolve " << CAF_ARG(locator));
-  bool running = true;
-  auto f = [&]() {
-    set_thread_id();
-    while (running) {
-      handle_io_event();
-      std::this_thread::sleep_for(milliseconds(100));
-    }
-  };
-  std::thread t{f};
-  auto proxy = unbox(mars.mm.remote_actor(locator));
-  CAF_MESSAGE("resolved actor");
-  CAF_CHECK(proxy != nullptr);
-  running = false;
-  t.join();
-  set_thread_id();
+  mars.mm.resolve(locator, mars.self);
+  mars.run();
+  earth.run();
+  mars.run();
+  mars.self->receive(
+    [](strong_actor_ptr& ptr, const std::set<std::string>&) {
+      CAF_MESSAGE("resolved actor!");
+      CAF_CHECK_NOT_EQUAL(ptr, nullptr);
+    },
+    [](const error& err) {
+      CAF_FAIL("got error while resolving: " << CAF_ARG(err));
+    },
+    after(std::chrono::seconds(0)) >>
+      [] { CAF_FAIL("manager did not respond with a proxy."); });
 }
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_net/test/net/backend/tcp.cpp
+++ b/libcaf_net/test/net/backend/tcp.cpp
@@ -47,21 +47,13 @@ behavior dummy_actor(event_based_actor*) {
 
 struct earth_node {
   uri operator()() {
-    return unbox(make_uri("tcp://localhost:12345"));
-  }
-
-  uint16_t port() {
-    return 12345;
+    return unbox(make_uri("tcp://earth"));
   }
 };
 
 struct mars_node {
   uri operator()() {
-    return unbox(make_uri("tcp://localhost:12346"));
-  }
-
-  uint16_t port() {
-    return 12346;
+    return unbox(make_uri("tcp://mars"));
   }
 };
 
@@ -70,7 +62,6 @@ struct config : actor_system_config {
   config() {
     Node this_node;
     put(content, "middleman.this-node", this_node());
-    put(content, "middleman.tcp-port", this_node.port());
     load<middleman, backend::tcp>();
   }
 };
@@ -143,7 +134,7 @@ CAF_TEST(doorman accept) {
   auth.port = backend->port();
   CAF_MESSAGE("trying to connect to earth at " << CAF_ARG(auth));
   auto sock = make_connected_tcp_stream_socket(auth);
-  handle_io_event();
+  run();
   CAF_CHECK(sock);
   auto guard = make_socket_guard(*sock);
   CAF_REQUIRE_EQUAL(earth.mpx->num_socket_managers(), 3);
@@ -174,6 +165,11 @@ CAF_TEST(publish) {
   CAF_CHECK(earth.sys.registry().get(path) != nullptr);
 }
 
+/*
+// TODO: `middleman.this-node` cannot be set according to randomly bound port of
+         the node. Thus, the test segfaults  when creating the new actor with
+         `nullptr` for the `endpoint_manager`...
+
 CAF_TEST(remote_actor) {
   using std::chrono::milliseconds;
   using std::chrono::seconds;
@@ -199,6 +195,6 @@ CAF_TEST(remote_actor) {
   running = false;
   t.join();
   set_thread_id();
-}
+}*/
 
 CAF_TEST_FIXTURE_SCOPE_END()

--- a/libcaf_net/test/net/backend/tcp.cpp
+++ b/libcaf_net/test/net/backend/tcp.cpp
@@ -24,38 +24,130 @@
 #include "caf/test/dsl.hpp"
 
 #include <string>
+#include <thread>
 
+#include "caf/actor_system_config.hpp"
 #include "caf/ip_endpoint.hpp"
 #include "caf/net/middleman.hpp"
 #include "caf/net/socket_guard.hpp"
 #include "caf/net/tcp_accept_socket.hpp"
+#include "caf/uri.hpp"
 
 using namespace caf;
 using namespace caf::net;
+using namespace std::literals::string_literals;
 
 namespace {
 
+behavior dummy_actor(event_based_actor*) {
+  return {
+    // nop
+  };
+}
+
+struct earth_node {
+  uri operator()() {
+    return unbox(make_uri("tcp://earth"));
+  }
+};
+
+struct mars_node {
+  uri operator()() {
+    return unbox(make_uri("tcp://mars"));
+  }
+};
+
+template <class Node>
 struct config : actor_system_config {
   config() {
-    put(content, "middleman.this-node", unbox(make_uri("tcp://earth")));
+    Node this_node;
+    put(content, "middleman.this-node", this_node());
     load<middleman, backend::tcp>();
   }
 };
 
-struct fixture : test_coordinator_fixture<config>, host_fixture {
-  using byte_buffer_ptr = std::shared_ptr<byte_buffer>;
+class planet_driver {
+public:
+  virtual ~planet_driver() {
+    // nop
+  }
 
-  fixture() : mm{sys.network_manager()}, mpx{mm.mpx()} {
+  virtual bool consume_message() = 0;
+
+  virtual bool handle_io_event() = 0;
+
+  virtual bool trigger_timeout() = 0;
+};
+
+template <class Node>
+class planet : public test_coordinator_fixture<config<Node>> {
+public:
+  planet(planet_driver& driver)
+    : mm(this->sys.network_manager()), mpx(mm.mpx()), driver_(driver) {
     mpx->set_thread_id();
-    handle_io_events();
+  }
+
+  node_id id() const {
+    return this->sys.node();
+  }
+
+  bool consume_message() override {
+    return driver_.consume_message();
   }
 
   bool handle_io_event() override {
-    return mpx->poll_once(false);
+    return driver_.handle_io_event();
+  }
+
+  bool trigger_timeout() override {
+    return driver_.trigger_timeout();
+  }
+
+  actor resolve(string_view locator) {
+    auto hdl = actor_cast<actor>(this->self);
+    this->sys.network_manager().resolve(unbox(make_uri(locator)), hdl);
+    this->run();
+    actor result;
+    this->self->receive(
+      [&](strong_actor_ptr& ptr, const std::set<std::string>&) {
+        CAF_MESSAGE("resolved " << locator);
+        result = actor_cast<actor>(std::move(ptr));
+      });
+    return result;
   }
 
   net::middleman& mm;
-  const multiplexer_ptr& mpx;
+  multiplexer_ptr mpx;
+
+private:
+  planet_driver& driver_;
+};
+
+struct fixture : host_fixture, planet_driver {
+  fixture() : earth(*this), mars(*this) {
+    run();
+    CAF_REQUIRE_EQUAL(earth.mpx->num_socket_managers(), 2);
+    CAF_REQUIRE_EQUAL(mars.mpx->num_socket_managers(), 2);
+  }
+
+  bool consume_message() override {
+    return earth.sched.try_run_once() || mars.sched.try_run_once();
+  }
+
+  bool handle_io_event() override {
+    return earth.mpx->poll_once(false) || mars.mpx->poll_once(false);
+  }
+
+  bool trigger_timeout() override {
+    return earth.sched.trigger_timeout() || mars.sched.trigger_timeout();
+  }
+
+  void run() {
+    earth.run();
+  }
+
+  planet<earth_node> earth;
+  planet<mars_node> mars;
 };
 
 } // namespace
@@ -63,45 +155,72 @@ struct fixture : test_coordinator_fixture<config>, host_fixture {
 CAF_TEST_FIXTURE_SCOPE(tcp_backend_tests, fixture)
 
 CAF_TEST(doorman accept) {
-  CAF_CHECK_EQUAL(mpx->num_socket_managers(), 2);
-  auto backend = mm.backend("tcp");
+  auto backend = earth.mm.backend("tcp");
   CAF_CHECK(backend);
-  auto port = backend->port();
-  CAF_MESSAGE("trying to connect to system with " << CAF_ARG(port));
-  ip_endpoint ep;
-  auto ep_str = std::string("[::1]:") + std::to_string(port);
-  if (auto err = detail::parse(ep_str, ep))
-    CAF_FAIL("could not parse " << CAF_ARG(ep_str) << " " << CAF_ARG(err));
-  auto sock = make_connected_tcp_stream_socket(ep);
-  if (!sock)
-    CAF_FAIL("could not connect");
-  auto guard = make_socket_guard(*sock);
+  uri::authority_type auth;
+  auth.host = "localhost"s;
+  auth.port = backend->port();
+  CAF_MESSAGE("trying to connect to earth at " << CAF_ARG(auth));
+  auto sock = make_connected_tcp_stream_socket(auth);
   handle_io_event();
-  CAF_CHECK_EQUAL(mpx->num_socket_managers(), 3);
+  CAF_CHECK(sock);
+  auto guard = make_socket_guard(*sock);
+  CAF_REQUIRE_EQUAL(earth.mpx->num_socket_managers(), 3);
 }
 
 CAF_TEST(connect) {
-  CAF_CHECK_EQUAL(mpx->num_socket_managers(), 2);
-  ip_endpoint ep;
-  if (auto err = detail::parse("[::]:0", ep))
-    CAF_FAIL("could not parse endpoint" << err);
-  auto acceptor = make_tcp_accept_socket(ep);
-  if (!acceptor)
-    CAF_FAIL("could not create acceptor" << CAF_ARG2("err", acceptor.error()));
-  auto acc_guard = make_socket_guard(*acceptor);
-  auto port = local_port(acc_guard.socket());
-  if (!port)
-    CAF_FAIL("could not read port" << CAF_ARG2("err", port.error()));
-  auto uri_str = std::string("tcp://localhost:") + std::to_string(*port);
+  uri::authority_type auth;
+  auth.host = "0.0.0.0"s;
+  auth.port = 0;
+  auto acceptor = unbox(make_tcp_accept_socket(auth, false));
+  auto acc_guard = make_socket_guard(acceptor);
+  auto port = unbox(local_port(acc_guard.socket()));
+  auto uri_str = std::string("tcp://localhost:") + std::to_string(port);
   CAF_MESSAGE("connecting to " << CAF_ARG(uri_str));
-  auto ret = mm.connect(*make_uri(uri_str));
-  if (!ret)
-    CAF_FAIL("could not connect to " << uri_str);
-  auto sock = accept(acc_guard.socket());
-  if (!sock)
-    CAF_FAIL("accepting failed");
+  unbox(earth.mm.connect(*make_uri(uri_str)));
+  CAF_CHECK(accept(acc_guard.socket()));
   handle_io_event();
-  CAF_CHECK_EQUAL(mpx->num_socket_managers(), 3);
+  CAF_REQUIRE_EQUAL(earth.mpx->num_socket_managers(), 3);
 }
 
+/*
+CAF_TEST(publish and resolve) {
+  auto dummy = sys.spawn(dummy_actor);
+  auto port = unbox(mm.port("tcp"));
+  auto locator = unbox(make_uri("tcp://localhost:"s + std::to_string(port)));
+  mm.publish(dummy, locator);
+  auto ret = sys.registry().get(
+    std::string(locator.path().begin(), locator.path().end()));
+  if (!ret)
+    CAF_FAIL("could not retrieve published actor");
+  config<mars_node> mars_cfg;
+  actor_system mars_sys{mars_cfg};
+  auto& mars_mm = mars_sys.network_manager();
+  auto mars_mpx = mars_mm.mpx();
+  mars_mpx->set_thread_id();
+  mars_mpx->poll_once(false);
+  CAF_REQUIRE(mars_mpx->num_socket_managers(), 2);
+  CAF_MESSAGE("connecting to " << CAF_ARG(locator));
+  unbox(mars_mm.connect(locator));
+  run();
+  mars_mpx->poll_once(false);
+  auto locator
+    = unbox(make_uri("tcp://localhost:"s + std::to_string(port) + "/dummy"));
+  CAF_MESSAGE("resolving actor " << CAF_ARG(actor_locator));
+  mars_mm.resolve(locator, self);
+  mars_mpx->poll_once(false);
+  run();
+  mars_mpx->poll_once(false);
+  CAF_MESSAGE("receiving actor");
+  self->receive(
+    [](strong_actor_ptr&, const std::set<std::string>&) {
+
+    },
+    [](const error& err) {
+      CAF_FAIL("error resolving actor " << CAF_ARG(err));
+    },
+    after(std::chrono::seconds(5)) >>
+      [] { CAF_FAIL("manager did not respond with a proxy."); });
+}
+*/
 CAF_TEST_FIXTURE_SCOPE_END()


### PR DESCRIPTION
This PR adds a `tcp_backend` and `publish` and `remote_actor` functions to the `middleman`.
closes #58 .