### PR TITLE
Fix buffer caching

### DIFF
--- a/libcaf_net/caf/net/transport_base.hpp
+++ b/libcaf_net/caf/net/transport_base.hpp
@@ -209,7 +209,7 @@ public:
 private:
   // -- utility functions ------------------------------------------------------
 
-  static byte_buffer next_buffer_impl(buffer_cache_type cache) {
+  static byte_buffer next_buffer_impl(buffer_cache_type& cache) {
     if (cache.empty())
       return {};
     auto buf = std::move(cache.back());


### PR DESCRIPTION
This PR fixes the buffer caching routine by adding a missing ref to the `next_buffer_impl` function.