### PR TITLE
Switch to more lightweight socket API wrapper

### DIFF
--- a/libcaf_net/caf/net/basp/application.hpp
+++ b/libcaf_net/caf/net/basp/application.hpp
@@ -82,9 +82,8 @@ public:
     system_ = &parent.system();
     executor_.system_ptr(system_);
     executor_.proxy_registry_ptr(&proxies_);
-    // TODO: use `if constexpr` when switching to C++17.
     // Allow unit tests to run the application without endpoint manager.
-    if (!std::is_base_of<test_tag, Parent>::value)
+    if constexpr (!std::is_base_of<test_tag, Parent>::value)
       manager_ = &parent.manager();
     size_t workers;
     if (auto workers_cfg = get_if<size_t>(&system_->config(),

--- a/libcaf_net/caf/net/pipe_socket.hpp
+++ b/libcaf_net/caf/net/pipe_socket.hpp
@@ -27,6 +27,10 @@
 #include "caf/net/socket.hpp"
 #include "caf/net/socket_id.hpp"
 
+// Note: This API mostly wraps platform-specific functions that return ssize_t.
+// We return ptrdiff_t instead, since only POSIX defines ssize_t and the two
+// types are functionally equivalent.
+
 namespace caf::net {
 
 /// A unidirectional communication endpoint for inter-process communication.
@@ -46,19 +50,13 @@ expected<std::pair<pipe_socket, pipe_socket>> CAF_NET_EXPORT make_pipe();
 /// @param buf Memory region for reading the message to send.
 /// @returns The number of written bytes on success, otherwise an error code.
 /// @relates pipe_socket
-variant<size_t, sec> CAF_NET_EXPORT write(pipe_socket x, span<const byte> buf);
+ptrdiff_t CAF_NET_EXPORT write(pipe_socket x, span<const byte> buf);
 
 /// Receives data from `x`.
 /// @param x Connected endpoint.
 /// @param buf Memory region for storing the received bytes.
 /// @returns The number of received bytes on success, otherwise an error code.
 /// @relates pipe_socket
-variant<size_t, sec> CAF_NET_EXPORT read(pipe_socket x, span<byte> buf);
-
-/// Converts the result from I/O operation on a ::pipe_socket to either an
-/// error code or a non-zero positive integer.
-/// @relates pipe_socket
-variant<size_t, sec>
-  CAF_NET_EXPORT check_pipe_socket_io_res(std::make_signed<size_t>::type res);
+ptrdiff_t CAF_NET_EXPORT read(pipe_socket x, span<byte> buf);
 
 } // namespace caf::net

--- a/libcaf_net/caf/net/socket.hpp
+++ b/libcaf_net/caf/net/socket.hpp
@@ -69,13 +69,21 @@ To CAF_NET_EXPORT socket_cast(From x) {
   return To{x.id};
 }
 
-/// Close socket `x`.
+/// Closes socket `x`.
 /// @relates socket
 void CAF_NET_EXPORT close(socket x);
 
 /// Returns the last socket error in this thread as an integer.
 /// @relates socket
 std::errc CAF_NET_EXPORT last_socket_error();
+
+/// Checks whether `last_socket_error()` would return an error code that
+/// indicates a temporary error.
+/// @returns `true` if `last_socket_error()` returned either
+/// `std::errc::operation_would_block` or
+/// `std::errc::resource_unavailable_try_again`, `false` otherwise.
+/// @relates socket
+bool CAF_NET_EXPORT last_socket_error_is_temporary();
 
 /// Returns the last socket error as human-readable string.
 /// @relates socket

--- a/libcaf_net/caf/net/stream_socket.hpp
+++ b/libcaf_net/caf/net/stream_socket.hpp
@@ -18,9 +18,15 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "caf/detail/net_export.hpp"
 #include "caf/fwd.hpp"
 #include "caf/net/network_socket.hpp"
+
+// Note: This API mostly wraps platform-specific functions that return ssize_t.
+// We return ptrdiff_t instead, since only POSIX defines ssize_t and the two
+// types are functionally equivalent.
 
 namespace caf::net {
 
@@ -47,37 +53,33 @@ error CAF_NET_EXPORT keepalive(stream_socket x, bool new_value);
 error CAF_NET_EXPORT nodelay(stream_socket x, bool new_value);
 
 /// Receives data from `x`.
-/// @param x Connected endpoint.
+/// @param x A connected endpoint.
 /// @param buf Points to destination buffer.
-/// @returns The number of received bytes on success, an error code otherwise.
+/// @returns The number of received bytes on success, 0 if the socket is closed,
+///          or -1 in case of an error.
 /// @relates stream_socket
-/// @post either the result is a `sec` or a positive (non-zero) integer
-variant<size_t, sec> CAF_NET_EXPORT read(stream_socket x, span<byte> buf);
+/// @post Either the functions returned a non-negative integer or the caller can
+///       retrieve the error code by calling `last_socket_error()`.
+ptrdiff_t CAF_NET_EXPORT read(stream_socket x, span<byte> buf);
 
-/// Transmits data from `x` to its peer.
-/// @param x Connected endpoint.
+/// Sends data to `x`.
+/// @param x A connected endpoint.
 /// @param buf Points to the message to send.
-/// @returns The number of written bytes on success, otherwise an error code.
+/// @returns The number of received bytes on success, 0 if the socket is closed,
+///          or -1 in case of an error.
 /// @relates stream_socket
 /// @post either the result is a `sec` or a positive (non-zero) integer
-variant<size_t, sec> CAF_NET_EXPORT write(stream_socket x,
-                                          span<const byte> buf);
+ptrdiff_t CAF_NET_EXPORT write(stream_socket x, span<const byte> buf);
 
 /// Transmits data from `x` to its peer.
-/// @param x Connected endpoint.
+/// @param x A connected endpoint.
 /// @param bufs Points to the message to send, scattered across up to 10
 ///             buffers.
 /// @returns The number of written bytes on success, otherwise an error code.
 /// @relates stream_socket
 /// @post either the result is a `sec` or a positive (non-zero) integer
 /// @pre `bufs.size() < 10`
-variant<size_t, sec> CAF_NET_EXPORT
-write(stream_socket x, std::initializer_list<span<const byte>> bufs);
-
-/// Converts the result from I/O operation on a ::stream_socket to either an
-/// error code or a non-zero positive integer.
-/// @relates stream_socket
-variant<size_t, sec>
-  CAF_NET_EXPORT check_stream_socket_io_res(std::make_signed<size_t>::type res);
+ptrdiff_t CAF_NET_EXPORT write(stream_socket x,
+                               std::initializer_list<span<const byte>> bufs);
 
 } // namespace caf::net

--- a/libcaf_net/src/net/middleman.cpp
+++ b/libcaf_net/src/net/middleman.cpp
@@ -105,7 +105,8 @@ void middleman::add_module_options(actor_system_config& cfg) {
                  "max. number of consecutive reads per broker")
     .add<bool>("manual-multiplexing",
                "disables background activity of the multiplexer")
-    .add<size_t>("workers", "number of deserialization workers");
+    .add<size_t>("workers", "number of deserialization workers")
+    .add<std::string>("network-backend", "legacy option");
 }
 
 expected<endpoint_manager_ptr> middleman::connect(const uri& locator) {

--- a/libcaf_net/src/pipe_socket.cpp
+++ b/libcaf_net/src/pipe_socket.cpp
@@ -49,12 +49,12 @@ expected<std::pair<pipe_socket, pipe_socket>> make_pipe() {
   }
 }
 
-variant<size_t, sec> write(pipe_socket x, span<const byte> buf) {
+ptrdiff_t write(pipe_socket x, span<const byte> buf) {
   // On Windows, a pipe consists of two stream sockets.
   return write(socket_cast<stream_socket>(x), buf);
 }
 
-variant<size_t, sec> read(pipe_socket x, span<byte> buf) {
+ptrdiff_t read(pipe_socket x, span<byte> buf) {
   // On Windows, a pipe consists of two stream sockets.
   return read(socket_cast<stream_socket>(x), buf);
 }
@@ -80,23 +80,16 @@ expected<std::pair<pipe_socket, pipe_socket>> make_pipe() {
   return std::make_pair(pipe_socket{pipefds[0]}, pipe_socket{pipefds[1]});
 }
 
-variant<size_t, sec> write(pipe_socket x, span<const byte> buf) {
-  auto res = ::write(x.id, reinterpret_cast<socket_send_ptr>(buf.data()),
-                     buf.size());
-  return check_pipe_socket_io_res(res);
+ptrdiff_t write(pipe_socket x, span<const byte> buf) {
+  return ::write(x.id, reinterpret_cast<socket_send_ptr>(buf.data()),
+                 buf.size());
 }
 
-variant<size_t, sec> read(pipe_socket x, span<byte> buf) {
-  auto res = ::read(x.id, reinterpret_cast<socket_recv_ptr>(buf.data()),
-                    buf.size());
-  return check_pipe_socket_io_res(res);
+ptrdiff_t read(pipe_socket x, span<byte> buf) {
+  return ::read(x.id, reinterpret_cast<socket_recv_ptr>(buf.data()),
+                buf.size());
 }
 
 #endif // CAF_WINDOWS
-
-variant<size_t, sec>
-check_pipe_socket_io_res(std::make_signed<size_t>::type res) {
-  return check_stream_socket_io_res(res);
-}
 
 } // namespace caf::net

--- a/libcaf_net/src/socket.cpp
+++ b/libcaf_net/src/socket.cpp
@@ -103,6 +103,11 @@ std::errc last_socket_error() {
   abort();
 }
 
+bool last_socket_error_is_temporary() {
+  int wsa_code = WSAGetLastError();
+  return wsa_code == WSAEWOULDBLOCK || wsa_code == WSATRY_AGAIN;
+}
+
 std::string last_socket_error_as_string() {
   int wsa_code = WSAGetLastError();
   LPTSTR errorText = NULL;
@@ -147,6 +152,15 @@ std::errc last_socket_error() {
   // TODO: Linux and macOS both have some non-POSIX error codes that should get
   // mapped accordingly.
   return static_cast<std::errc>(errno);
+}
+
+bool last_socket_error_is_temporary() {
+  auto code = errno;
+#  if EAGAIN == EWOULDBLOCK
+  return code == EAGAIN;
+#  else
+  return code == EAGAIN || code == EWOULDBLOCK;
+#  endif
 }
 
 std::string last_socket_error_as_string() {

--- a/libcaf_net/test/application.cpp
+++ b/libcaf_net/test/application.cpp
@@ -29,6 +29,7 @@
 #include "caf/net/basp/connection_state.hpp"
 #include "caf/net/basp/constants.hpp"
 #include "caf/net/basp/ec.hpp"
+#include "caf/net/middleman.hpp"
 #include "caf/net/packet_writer.hpp"
 #include "caf/none.hpp"
 #include "caf/uri.hpp"
@@ -42,7 +43,13 @@ using namespace caf::net;
 
 namespace {
 
-struct fixture : test_coordinator_fixture<>,
+struct config : actor_system_config {
+  config() {
+    net::middleman::add_module_options(*this);
+  }
+};
+
+struct fixture : test_coordinator_fixture<config>,
                  proxy_registry::backend,
                  basp::application::test_tag,
                  public packet_writer {
@@ -242,8 +249,7 @@ CAF_TEST(actor message) {
   MOCK(basp::message_type::actor_message, make_message_id().integer_value(),
        mars, actor_id{42}, self->id(), std::vector<strong_actor_ptr>{},
        make_message("hello world!"));
-  allow((monitor_atom, strong_actor_ptr),
-        from(_).to(self).with(monitor_atom_v, _));
+  expect((monitor_atom, strong_actor_ptr), from(_).to(self));
   expect((std::string), from(_).to(self).with("hello world!"));
 }
 

--- a/libcaf_net/test/endpoint_manager.cpp
+++ b/libcaf_net/test/endpoint_manager.cpp
@@ -164,7 +164,7 @@ CAF_TEST(send and receive) {
   auto buf = std::make_shared<byte_buffer>();
   auto sockets = unbox(make_stream_socket_pair());
   CAF_CHECK_EQUAL(nonblocking(sockets.second, true), none);
-  CAF_CHECK_EQUAL(read(sockets.second, read_buf), -1);
+  CAF_CHECK_LESS(read(sockets.second, read_buf), 0);
   CAF_CHECK(last_socket_error_is_temporary());
   auto guard = detail::make_scope_guard([&] { close(sockets.second); });
   auto mgr = make_endpoint_manager(mpx, sys,

--- a/libcaf_net/test/stream_socket.cpp
+++ b/libcaf_net/test/stream_socket.cpp
@@ -75,8 +75,10 @@ struct fixture : host_fixture {
 CAF_TEST_FIXTURE_SCOPE(network_socket_tests, fixture)
 
 CAF_TEST(read on empty sockets) {
-  CAF_CHECK_EQUAL(read(first, rd_buf), sec::unavailable_or_would_block);
-  CAF_CHECK_EQUAL(read(second, rd_buf), sec::unavailable_or_would_block);
+  CAF_CHECK_EQUAL(read(first, rd_buf), -1);
+  CAF_CHECK(last_socket_error_is_temporary());
+  CAF_CHECK_EQUAL(read(second, rd_buf), -1);
+  CAF_CHECK(last_socket_error_is_temporary());
 }
 
 CAF_TEST(transfer data from first to second socket) {
@@ -97,7 +99,7 @@ CAF_TEST(transfer data from second to first socket) {
 
 CAF_TEST(shut down first socket and observe shutdown on the second one) {
   close(first);
-  CAF_CHECK_EQUAL(read(second, rd_buf), sec::socket_disconnected);
+  CAF_CHECK_EQUAL(read(second, rd_buf), 0);
   first.id = invalid_socket_id;
 }
 

--- a/libcaf_net/test/stream_socket.cpp
+++ b/libcaf_net/test/stream_socket.cpp
@@ -75,9 +75,9 @@ struct fixture : host_fixture {
 CAF_TEST_FIXTURE_SCOPE(network_socket_tests, fixture)
 
 CAF_TEST(read on empty sockets) {
-  CAF_CHECK_EQUAL(read(first, rd_buf), -1);
+  CAF_CHECK_LESS(read(first, rd_buf), 0);
   CAF_CHECK(last_socket_error_is_temporary());
-  CAF_CHECK_EQUAL(read(second, rd_buf), -1);
+  CAF_CHECK_LESS(read(second, rd_buf), 0);
   CAF_CHECK(last_socket_error_is_temporary());
 }
 

--- a/libcaf_net/test/stream_transport.cpp
+++ b/libcaf_net/test/stream_transport.cpp
@@ -184,9 +184,11 @@ CAF_TEST(resolve and proxy communication) {
       [&] { CAF_FAIL("manager did not respond with a proxy."); });
   run();
   auto read_res = read(recv_socket_guard.socket(), recv_buf);
-  if (!holds_alternative<size_t>(read_res))
-    CAF_FAIL("read() returned an error: " << get<sec>(read_res));
-  recv_buf.resize(get<size_t>(read_res));
+  if (read_res < 0)
+    CAF_FAIL("read() returned an error: " << last_socket_error_as_string);
+  else if (read_res == 0)
+    CAF_FAIL("read() returned 0 (socket closed)");
+  recv_buf.resize(static_cast<size_t>(read_res));
   CAF_MESSAGE("receive buffer contains " << recv_buf.size() << " bytes");
   message msg;
   binary_deserializer source{sys, recv_buf};

--- a/libcaf_net/test/string_application.cpp
+++ b/libcaf_net/test/string_application.cpp
@@ -208,8 +208,8 @@ CAF_TEST(receive) {
   auto buf = std::make_shared<byte_buffer>();
   auto sockets = unbox(make_stream_socket_pair());
   CAF_CHECK_EQUAL(nonblocking(sockets.second, true), none);
-  CAF_CHECK_EQUAL(read(sockets.second, read_buf),
-                  sec::unavailable_or_would_block);
+  CAF_CHECK_LESS(read(sockets.second, read_buf), 0);
+  CAF_CHECK(last_socket_error_is_temporary());
   CAF_MESSAGE("adding both endpoint managers");
   auto mgr1 = make_endpoint_manager(
     mpx, sys, transport_type{sockets.first, application_type{buf}});


### PR DESCRIPTION
The current API with `variant<size_t, sec>` has some nice semantic properties, but comes at a cost. This set of changes essentially reverts the socket API to a thin wrapper over the POSIX interface, but using `ptrdiff_t` instead of `ssize_t` (the latter is no C standard type).